### PR TITLE
feat(worker): add bookings API router

### DIFF
--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -36,3 +36,22 @@ export const appointmentAvailabilitySchema = z.object({
 export type TenantInput = z.infer<typeof tenantSchema>;
 export type UserInput = z.infer<typeof userSchema>;
 export type AppointmentAvailabilityInput = z.infer<typeof appointmentAvailabilitySchema>;
+
+export const bookingCreateSchema = z.object({
+  clientId: z.string().uuid(),
+  serviceId: z.string().uuid(),
+  stylistId: z.string().uuid().optional(),
+  startTime: z.string(),
+  endTime: z.string().optional(),
+  status: z.enum(['pending', 'confirmed', 'checked_in', 'completed', 'cancelled']).default('pending'),
+  notes: z.string().max(2000).optional(),
+  metadata: z.record(z.unknown()).optional()
+});
+
+export const bookingUpdateSchema = bookingCreateSchema.partial().refine(
+  (value) => Object.keys(value).length > 0,
+  { message: 'At least one field must be provided for update' }
+);
+
+export type BookingCreateInput = z.infer<typeof bookingCreateSchema>;
+export type BookingUpdateInput = z.infer<typeof bookingUpdateSchema>;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,6 +1,7 @@
 export type TenantId = string;
 export type UserId = string;
 export type AppointmentId = string;
+export type BookingId = string;
 
 export interface Tenant {
   id: TenantId;
@@ -91,6 +92,30 @@ export interface Appointment {
   createdBy: UserId;
   createdAt: string;
   updatedAt: string;
+}
+
+export type BookingStatus =
+  | 'pending'
+  | 'confirmed'
+  | 'checked_in'
+  | 'completed'
+  | 'cancelled';
+
+export interface Booking {
+  id: BookingId;
+  tenantId: TenantId;
+  clientId: string;
+  serviceId: string;
+  stylistId?: string;
+  startTime: string;
+  endTime?: string;
+  status: BookingStatus;
+  notes?: string;
+  metadata?: Record<string, unknown>;
+  createdBy: UserId;
+  createdAt: string;
+  updatedAt: string;
+  cancelledAt?: string;
 }
 
 export interface MessageLog {

--- a/workers/api/src/index.ts
+++ b/workers/api/src/index.ts
@@ -12,6 +12,7 @@ import { marketingRouter } from './routes/marketing';
 import { withErrorHandling } from './middleware/error-handler';
 import { withTenant } from './middleware/tenant';
 import { withAuth } from './middleware/auth';
+import { bookingRouter } from './routes/bookings';
 
 const router = Router();
 
@@ -21,6 +22,8 @@ router.all('/tenants', tenantRouter.handle);
 router.all('/tenants/*', tenantRouter.handle);
 router.all('/appointments', appointmentRouter.handle);
 router.all('/appointments/*', appointmentRouter.handle);
+router.all('/bookings', bookingRouter.handle);
+router.all('/bookings/*', bookingRouter.handle);
 router.all('/clients', clientRouter.handle);
 router.all('/clients/*', clientRouter.handle);
 router.all('/stylists', stylistRouter.handle);

--- a/workers/api/src/routes/bookings.ts
+++ b/workers/api/src/routes/bookings.ts
@@ -1,0 +1,79 @@
+import { Router } from 'itty-router';
+import { z } from 'zod';
+import {
+  bookingCreateSchema,
+  bookingUpdateSchema
+} from '@ai-hairdresser/shared';
+import { JsonResponse } from '../lib/response';
+import {
+  cancelBooking,
+  createBooking,
+  listBookings,
+  updateBooking
+} from '../services/booking-service';
+
+const router = Router({ base: '/bookings' });
+
+const listBookingsQuerySchema = z.object({
+  start_time: z.string().datetime().optional()
+});
+
+type RequestWithParams = TenantScopedRequest & { params?: Record<string, string> };
+
+router.get('/', async (request: TenantScopedRequest, env: Env) => {
+  const url = new URL(request.url);
+  const rawQuery = Object.fromEntries(url.searchParams);
+  const parsedQuery = listBookingsQuerySchema.safeParse(rawQuery);
+  if (!parsedQuery.success) {
+    return JsonResponse.error('Invalid query parameters', 400, parsedQuery.error.flatten());
+  }
+
+  const bookings = await listBookings(env, request.tenantId!, {
+    startTime: parsedQuery.data.start_time
+  });
+
+  return JsonResponse.ok({ bookings });
+});
+
+router.post('/', async (request: TenantScopedRequest, env: Env) => {
+  const body = await request.json();
+  const parsed = bookingCreateSchema.safeParse(body);
+  if (!parsed.success) {
+    return JsonResponse.error('Invalid payload', 400, parsed.error.flatten());
+  }
+
+  if (!request.userId) {
+    return JsonResponse.error('Missing user context', 401);
+  }
+
+  const booking = await createBooking(env, request.tenantId!, request.userId, parsed.data);
+  return JsonResponse.ok({ booking }, { status: 201 });
+});
+
+router.patch('/:id', async (request: RequestWithParams, env: Env) => {
+  const bookingId = request.params?.id;
+  if (!bookingId) {
+    return JsonResponse.error('Missing booking id', 400);
+  }
+
+  const body = await request.json();
+  const parsed = bookingUpdateSchema.safeParse(body);
+  if (!parsed.success) {
+    return JsonResponse.error('Invalid payload', 400, parsed.error.flatten());
+  }
+
+  const booking = await updateBooking(env, request.tenantId!, bookingId, parsed.data);
+  return JsonResponse.ok({ booking });
+});
+
+router.delete('/:id', async (request: RequestWithParams, env: Env) => {
+  const bookingId = request.params?.id;
+  if (!bookingId) {
+    return JsonResponse.error('Missing booking id', 400);
+  }
+
+  const booking = await cancelBooking(env, request.tenantId!, bookingId);
+  return JsonResponse.ok({ booking });
+});
+
+export const bookingRouter = router;

--- a/workers/api/src/services/booking-service.ts
+++ b/workers/api/src/services/booking-service.ts
@@ -1,0 +1,161 @@
+import { createClient } from '@supabase/supabase-js';
+import type {
+  Booking,
+  BookingCreateInput,
+  BookingUpdateInput
+} from '@ai-hairdresser/shared';
+
+interface BookingRow {
+  id: string;
+  tenant_id: string;
+  client_id: string;
+  service_id: string;
+  stylist_id?: string | null;
+  start_time: string;
+  end_time?: string | null;
+  status: string;
+  notes?: string | null;
+  metadata?: Record<string, unknown> | null;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+  cancelled_at?: string | null;
+}
+
+const BOOKING_COLUMNS =
+  'id, tenant_id, client_id, service_id, stylist_id, start_time, end_time, status, notes, metadata, created_by, created_at, updated_at, cancelled_at';
+
+function getClient(env: Env) {
+  return createClient(env.SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY);
+}
+
+function mapBooking(row: BookingRow): Booking {
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    clientId: row.client_id,
+    serviceId: row.service_id,
+    stylistId: row.stylist_id ?? undefined,
+    startTime: row.start_time,
+    endTime: row.end_time ?? undefined,
+    status: row.status as Booking['status'],
+    notes: row.notes ?? undefined,
+    metadata: row.metadata ?? undefined,
+    createdBy: row.created_by,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    cancelledAt: row.cancelled_at ?? undefined
+  };
+}
+
+export interface ListBookingsOptions {
+  startTime?: string;
+}
+
+export async function listBookings(env: Env, tenantId: string, options: ListBookingsOptions = {}) {
+  const client = getClient(env);
+  let query = client
+    .from('bookings')
+    .select(BOOKING_COLUMNS)
+    .eq('tenant_id', tenantId)
+    .order('start_time', { ascending: true });
+
+  if (options.startTime) {
+    query = query.gte('start_time', options.startTime);
+  }
+
+  const { data, error } = await query;
+  if (error) {
+    throw new Error(`Failed to list bookings: ${error.message}`);
+  }
+
+  return (data ?? []).map((row) => mapBooking(row as BookingRow));
+}
+
+export async function createBooking(
+  env: Env,
+  tenantId: string,
+  userId: string,
+  input: BookingCreateInput
+) {
+  const client = getClient(env);
+  const now = new Date().toISOString();
+  const insertPayload = {
+    tenant_id: tenantId,
+    client_id: input.clientId,
+    service_id: input.serviceId,
+    stylist_id: input.stylistId ?? null,
+    start_time: input.startTime,
+    end_time: input.endTime ?? null,
+    status: input.status ?? 'pending',
+    notes: input.notes ?? null,
+    metadata: input.metadata ?? null,
+    created_by: userId,
+    updated_at: now
+  };
+
+  const { data, error } = await client
+    .from('bookings')
+    .insert(insertPayload)
+    .select(BOOKING_COLUMNS)
+    .single();
+
+  if (error || !data) {
+    throw new Error(`Failed to create booking: ${error?.message ?? 'Unknown error'}`);
+  }
+
+  return mapBooking(data as BookingRow);
+}
+
+export async function updateBooking(
+  env: Env,
+  tenantId: string,
+  bookingId: string,
+  input: BookingUpdateInput
+) {
+  const client = getClient(env);
+  const updates: Record<string, unknown> = {};
+
+  if (input.clientId !== undefined) updates.client_id = input.clientId;
+  if (input.serviceId !== undefined) updates.service_id = input.serviceId;
+  if (input.stylistId !== undefined) updates.stylist_id = input.stylistId ?? null;
+  if (input.startTime !== undefined) updates.start_time = input.startTime;
+  if (input.endTime !== undefined) updates.end_time = input.endTime ?? null;
+  if (input.status !== undefined) updates.status = input.status;
+  if (input.notes !== undefined) updates.notes = input.notes ?? null;
+  if (input.metadata !== undefined) updates.metadata = input.metadata ?? null;
+
+  updates.updated_at = new Date().toISOString();
+
+  const { data, error } = await client
+    .from('bookings')
+    .update(updates)
+    .eq('tenant_id', tenantId)
+    .eq('id', bookingId)
+    .select(BOOKING_COLUMNS)
+    .single();
+
+  if (error || !data) {
+    throw new Error(`Failed to update booking: ${error?.message ?? 'Unknown error'}`);
+  }
+
+  return mapBooking(data as BookingRow);
+}
+
+export async function cancelBooking(env: Env, tenantId: string, bookingId: string) {
+  const client = getClient(env);
+  const timestamp = new Date().toISOString();
+  const { data, error } = await client
+    .from('bookings')
+    .update({ status: 'cancelled', cancelled_at: timestamp, updated_at: timestamp })
+    .eq('tenant_id', tenantId)
+    .eq('id', bookingId)
+    .select(BOOKING_COLUMNS)
+    .single();
+
+  if (error || !data) {
+    throw new Error(`Failed to cancel booking: ${error?.message ?? 'Unknown error'}`);
+  }
+
+  return mapBooking(data as BookingRow);
+}


### PR DESCRIPTION
## Summary
- add shared booking schemas and types for booking contracts
- implement a Supabase-backed bookings service and router with Zod validation
- register the bookings router on the worker entrypoint for tenant-scoped access

## Testing
- npm install *(fails: No matching version found for @supabase/auth-helpers-react@^0.4.6)*

------
https://chatgpt.com/codex/tasks/task_e_68e43de57df8832995b3001ce6b55f1b