### PR TITLE
Add Twilio booking notification stub with retries

### DIFF
--- a/workers/api/src/integrations/twilio.ts
+++ b/workers/api/src/integrations/twilio.ts
@@ -14,3 +14,44 @@ export function createTwilioClient(env: Env) {
     }
   };
 }
+
+function maskRecipient(recipient: string) {
+  if (!recipient) return 'unknown';
+  const trimmed = recipient.replace(/\s+/g, '');
+  return trimmed.length <= 4 ? `***${trimmed}` : `***${trimmed.slice(-4)}`;
+}
+
+export async function sendBookingNotification(env: Env, to: string, message: string) {
+  const client = createTwilioClient(env);
+  const maxAttempts = 3;
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      await client.sendSms(to, message);
+      console.log('Booking notification dispatched via Twilio', {
+        attempt,
+        to: maskRecipient(to)
+      });
+      return { success: true };
+    } catch (error) {
+      lastError = error;
+      console.error('Booking notification attempt failed', {
+        attempt,
+        to: maskRecipient(to),
+        error: error instanceof Error ? error.message : String(error)
+      });
+      if (attempt < maxAttempts) {
+        const delay = 250 * Math.pow(2, attempt - 1);
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+    }
+  }
+
+  console.error('Booking notification failed after retries', {
+    to: maskRecipient(to),
+    error: lastError instanceof Error ? lastError.message : String(lastError ?? 'unknown')
+  });
+
+  return { success: false, error: lastError };
+}


### PR DESCRIPTION
## Summary
- add a Twilio booking notification helper that retries and masks recipient logs
- trigger the Twilio SMS stub when creating an appointment so booking confirmations are attempted without blocking the client response
- log missing recipients and keep HTTP 200 responses even when Twilio retries fail

## Testing
- npm run build --workspace workers/api *(fails: wrangler: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e43e1f6f688329b719a71a014400ff