### PR TITLE
Add Stripe booking deposit workflow

### DIFF
--- a/apps/web/pages/dashboard/index.tsx
+++ b/apps/web/pages/dashboard/index.tsx
@@ -8,6 +8,8 @@ type DashboardSummary = {
   pendingConfirmations: number;
   pendingMessages: number;
   revenueLast30d: number;
+  pendingDeposits: number;
+  collectedDeposits: number;
 };
 
 const fetcher = (path: string) => apiFetch<DashboardSummary>(path);
@@ -53,6 +55,14 @@ export default function DashboardPage() {
               <article>
                 <h2>Revenue (30d)</h2>
                 <p>£{data.revenueLast30d?.toFixed(2)}</p>
+              </article>
+              <article>
+                <h2>Deposits pending</h2>
+                <p>{data.pendingDeposits}</p>
+              </article>
+              <article>
+                <h2>Deposits collected</h2>
+                <p>{data.collectedDeposits}</p>
               </article>
             </div>
           )}

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -9,6 +9,7 @@ export const tenantSchema = z.object({
   settings: z.object({
     defaultDepositType: z.enum(['fixed', 'percentage']).default('percentage'),
     defaultDepositValue: z.number().nonnegative().default(20),
+    depositsEnabled: z.boolean().default(false),
     timezone: z.string(),
     locale: z.string(),
     cancellationPolicy: z.string()

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -17,6 +17,7 @@ export interface Tenant {
 export interface TenantSettings {
   defaultDepositType: 'fixed' | 'percentage';
   defaultDepositValue: number;
+  depositsEnabled: boolean;
   timezone: string;
   locale: string;
   cancellationPolicy: string;
@@ -72,10 +73,25 @@ export interface Service {
   name: string;
   durationMinutes: number;
   price: number;
+  requiresDeposit: boolean;
   depositType?: 'fixed' | 'percentage';
   depositValue?: number;
   createdAt: string;
   updatedAt: string;
+}
+
+export type BookingDepositStatus = 'pending' | 'paid' | 'failed' | 'cancelled';
+
+export interface BookingDeposit {
+  required: boolean;
+  status: BookingDepositStatus;
+  amount?: number;
+  currency?: string;
+  checkoutSessionId?: string;
+  checkoutUrl?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  paidAt?: string;
 }
 
 export interface Appointment {
@@ -116,6 +132,7 @@ export interface Booking {
   createdAt: string;
   updatedAt: string;
   cancelledAt?: string;
+  deposit?: BookingDeposit;
 }
 
 export interface MessageLog {

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -71,6 +71,7 @@ create table if not exists services (
   name text not null,
   duration_minutes integer not null,
   price numeric(10,2) not null,
+  requires_deposit boolean default false,
   deposit_type text check (deposit_type in ('fixed','percentage')),
   deposit_value numeric(10,2),
   created_at timestamp with time zone default timezone('utc', now()),
@@ -102,6 +103,7 @@ create table if not exists bookings (
   start_time timestamp with time zone not null,
   end_time timestamp with time zone not null,
   status text not null check (status in ('pending','confirmed','cancelled','no_show','completed')) default 'pending',
+  metadata jsonb default '{}'::jsonb,
   created_at timestamp with time zone default timezone('utc', now()),
   updated_at timestamp with time zone default timezone('utc', now())
 );

--- a/workers/api/src/integrations/stripe.ts
+++ b/workers/api/src/integrations/stripe.ts
@@ -1,16 +1,201 @@
-export function createStripeClient(env: Env) {
-  if (!env.STRIPE_SECRET_KEY) {
-    console.warn('Missing STRIPE_SECRET_KEY');
+const STRIPE_API_BASE = 'https://api.stripe.com/v1';
+
+type StripeCheckoutSessionOptions = {
+  amount: number;
+  currency: string;
+  clientReferenceId: string;
+  successUrl: string;
+  cancelUrl: string;
+  productName: string;
+  description?: string;
+  customerEmail?: string;
+  metadata?: Record<string, string | number | undefined | null>;
+};
+
+type StripeCheckoutSession = {
+  id: string;
+  url?: string;
+  payment_intent?: string;
+  [key: string]: unknown;
+};
+
+type StripeEvent = {
+  id: string;
+  type: string;
+  data?: { object?: Record<string, unknown> };
+  [key: string]: unknown;
+};
+
+function normaliseMetadata(metadata?: Record<string, unknown>) {
+  if (!metadata) {
+    return undefined;
   }
 
+  const normalised: Record<string, string> = {};
+  for (const [key, value] of Object.entries(metadata)) {
+    if (value === undefined || value === null) continue;
+    normalised[key] = String(value);
+  }
+  return normalised;
+}
+
+function timingSafeEqual(a: string, b: string) {
+  if (a.length !== b.length) {
+    return false;
+  }
+  let result = 0;
+  for (let i = 0; i < a.length; i++) {
+    result |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return result === 0;
+}
+
+function bufferToHex(buffer: ArrayBuffer) {
+  return Array.from(new Uint8Array(buffer))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function parseStripeSignatureHeader(header: string) {
+  const parts = header.split(',');
+  let timestamp: string | null = null;
+  const signatures: string[] = [];
+
+  for (const part of parts) {
+    const [key, value] = part.split('=');
+    if (!key || !value) continue;
+    if (key === 't') {
+      timestamp = value;
+    }
+    if (key === 'v1') {
+      signatures.push(value);
+    }
+  }
+
+  return { timestamp, signatures };
+}
+
+async function verifyStripeSignature(secret: string, signature: string, payload: string) {
+  const { timestamp, signatures } = parseStripeSignatureHeader(signature);
+  if (!timestamp || signatures.length === 0) {
+    throw new Error('Invalid Stripe signature header');
+  }
+
+  const encoder = new TextEncoder();
+  const signedPayload = `${timestamp}.${payload}`;
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const signatureBuffer = await crypto.subtle.sign('HMAC', key, encoder.encode(signedPayload));
+  const expectedSignature = bufferToHex(signatureBuffer);
+
+  const isValid = signatures.some((candidate) => timingSafeEqual(candidate, expectedSignature));
+  if (!isValid) {
+    throw new Error('Stripe signature verification failed');
+  }
+}
+
+async function stripeRequest(env: Env, path: string, params: URLSearchParams) {
+  if (!env.STRIPE_SECRET_KEY) {
+    console.warn('Missing STRIPE_SECRET_KEY; returning stubbed response');
+    return null;
+  }
+
+  const response = await fetch(`${STRIPE_API_BASE}${path}`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${env.STRIPE_SECRET_KEY}`,
+      'Content-Type': 'application/x-www-form-urlencoded'
+    },
+    body: params,
+    redirect: 'follow'
+  });
+
+  if (!response.ok) {
+    const payload = await response.json().catch(() => ({}));
+    const message = (payload as Record<string, unknown>)?.error
+      ? JSON.stringify((payload as Record<string, unknown>).error)
+      : `status ${response.status}`;
+    throw new Error(`Stripe API error: ${message}`);
+  }
+
+  return response.json();
+}
+
+export function createStripeClient(env: Env) {
   return {
     async createPaymentIntent(options: { amount: number; currency: string; metadata?: Record<string, string> }) {
-      console.log('TODO: call Stripe payment intent API', options);
-      return { id: 'pi_placeholder', client_secret: 'secret_placeholder' };
+      const params = new URLSearchParams();
+      params.append('amount', String(options.amount));
+      params.append('currency', options.currency);
+      params.append('payment_method_types[]', 'card');
+
+      const metadata = normaliseMetadata(options.metadata);
+      if (metadata) {
+        for (const [key, value] of Object.entries(metadata)) {
+          params.append(`metadata[${key}]`, value);
+        }
+      }
+
+      const result = await stripeRequest(env, '/payment_intents', params);
+      if (!result) {
+        return { id: `pi_test_${crypto.randomUUID()}`, client_secret: 'secret_placeholder' };
+      }
+      return result;
     },
-    async retrieveEvent(signature: string | null, payload: string) {
-      console.log('TODO: verify Stripe webhook signature', { signature, payloadLength: payload.length });
-      return { id: 'evt_placeholder', type: 'payment_intent.succeeded' };
+
+    async createCheckoutSession(options: StripeCheckoutSessionOptions): Promise<StripeCheckoutSession> {
+      const params = new URLSearchParams();
+      params.append('mode', 'payment');
+      params.append('payment_method_types[0]', 'card');
+      params.append('client_reference_id', options.clientReferenceId);
+      params.append('success_url', options.successUrl);
+      params.append('cancel_url', options.cancelUrl);
+      params.append('line_items[0][quantity]', '1');
+      params.append('line_items[0][price_data][currency]', options.currency);
+      params.append('line_items[0][price_data][unit_amount]', String(options.amount));
+      params.append('line_items[0][price_data][product_data][name]', options.productName);
+      if (options.description) {
+        params.append('line_items[0][price_data][product_data][description]', options.description);
+      }
+      if (options.customerEmail) {
+        params.append('customer_email', options.customerEmail);
+      }
+
+      const metadata = normaliseMetadata(options.metadata);
+      if (metadata) {
+        for (const [key, value] of Object.entries(metadata)) {
+          params.append(`metadata[${key}]`, value);
+        }
+      }
+
+      const result = await stripeRequest(env, '/checkout/sessions', params);
+      if (!result) {
+        return {
+          id: `cs_test_${crypto.randomUUID()}`,
+          url: 'https://checkout.stripe.com/test-session',
+          payment_intent: undefined
+        };
+      }
+      return result as StripeCheckoutSession;
+    },
+
+    async retrieveEvent(signature: string | null, payload: string): Promise<StripeEvent> {
+      if (!payload) {
+        throw new Error('Empty Stripe webhook payload');
+      }
+
+      if (!env.STRIPE_WEBHOOK_SECRET || !signature) {
+        console.warn('Skipping Stripe signature verification; secret not configured');
+        return JSON.parse(payload) as StripeEvent;
+      }
+
+      await verifyStripeSignature(env.STRIPE_WEBHOOK_SECRET, signature, payload);
+      return JSON.parse(payload) as StripeEvent;
     }
   };
 }

--- a/workers/api/src/routes/bookings.ts
+++ b/workers/api/src/routes/bookings.ts
@@ -46,8 +46,8 @@ router.post('/', async (request: TenantScopedRequest, env: Env) => {
     return JsonResponse.error('Missing user context', 401);
   }
 
-  const booking = await createBooking(env, request.tenantId!, request.userId, parsed.data);
-  return JsonResponse.ok({ booking }, { status: 201 });
+  const { booking, checkoutUrl } = await createBooking(env, request.tenantId!, request.userId, parsed.data);
+  return JsonResponse.ok({ booking, checkoutUrl }, { status: 201 });
 });
 
 router.patch('/:id', async (request: RequestWithParams, env: Env) => {

--- a/workers/api/src/routes/webhooks.ts
+++ b/workers/api/src/routes/webhooks.ts
@@ -1,6 +1,7 @@
 import { Router } from 'itty-router';
 import { JsonResponse } from '../lib/response';
 import { createStripeClient } from '../integrations/stripe';
+import { handleStripeEvent } from '../services/payment-service';
 import { handleInboundMessage } from '../services/messaging-service';
 
 const router = Router({ base: '/webhooks' });
@@ -9,9 +10,15 @@ router.post('/stripe', async (request: Request, env: Env) => {
   const signature = request.headers.get('stripe-signature');
   const payload = await request.text();
   const stripe = createStripeClient(env);
-  const event = await stripe.retrieveEvent(signature, payload);
-  console.log('Stripe event', event);
-  return JsonResponse.ok({ received: true });
+
+  try {
+    const event = await stripe.retrieveEvent(signature, payload);
+    await handleStripeEvent(env, event as Record<string, unknown>);
+    return JsonResponse.ok({ received: true });
+  } catch (error) {
+    console.error('Stripe webhook error', error);
+    return JsonResponse.error('Unable to process Stripe webhook', 400);
+  }
 });
 
 router.post('/twilio', async (request: Request, env: Env) => {

--- a/workers/api/src/services/booking-service.ts
+++ b/workers/api/src/services/booking-service.ts
@@ -2,8 +2,12 @@ import { createClient } from '@supabase/supabase-js';
 import type {
   Booking,
   BookingCreateInput,
-  BookingUpdateInput
+  BookingDeposit,
+  BookingDepositStatus,
+  BookingUpdateInput,
+  TenantSettings
 } from '@ai-hairdresser/shared';
+import { createStripeClient } from '../integrations/stripe';
 
 interface BookingRow {
   id: string;
@@ -22,6 +26,26 @@ interface BookingRow {
   cancelled_at?: string | null;
 }
 
+interface ServiceRow {
+  id: string;
+  tenant_id: string;
+  name: string;
+  price: number | string;
+  requires_deposit: boolean | null;
+  deposit_type?: 'fixed' | 'percentage' | null;
+  deposit_value?: number | string | null;
+}
+
+interface TenantRow {
+  settings: Partial<TenantSettings> | null;
+}
+
+interface ClientRow {
+  email?: string | null;
+  first_name?: string | null;
+  last_name?: string | null;
+}
+
 const BOOKING_COLUMNS =
   'id, tenant_id, client_id, service_id, stylist_id, start_time, end_time, status, notes, metadata, created_by, created_at, updated_at, cancelled_at';
 
@@ -29,7 +53,105 @@ function getClient(env: Env) {
   return createClient(env.SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY);
 }
 
+const DEFAULT_CHECKOUT_SUCCESS_URL = 'https://example.com/booking/success';
+const DEFAULT_CHECKOUT_CANCEL_URL = 'https://example.com/booking/cancel';
+
+function toNumber(value: number | string | null | undefined) {
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') {
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}
+
+function roundCurrency(amount: number) {
+  return Math.round(amount * 100) / 100;
+}
+
+function parseDepositMetadata(metadata: Record<string, unknown> | undefined | null): BookingDeposit | undefined {
+  if (!metadata || typeof metadata !== 'object') {
+    return undefined;
+  }
+
+  const rawDeposit = (metadata as Record<string, unknown>).deposit;
+  if (!rawDeposit || typeof rawDeposit !== 'object') {
+    return undefined;
+  }
+
+  const deposit = rawDeposit as Record<string, unknown>;
+  const required = Boolean(deposit.required);
+  const status = (typeof deposit.status === 'string'
+    ? deposit.status
+    : required
+      ? 'pending'
+      : 'cancelled') as BookingDepositStatus;
+
+  const amountValue = deposit.amount;
+  const amount =
+    typeof amountValue === 'number'
+      ? amountValue
+      : typeof amountValue === 'string'
+        ? Number.parseFloat(amountValue)
+        : undefined;
+
+  const currency = typeof deposit.currency === 'string' ? deposit.currency : undefined;
+  const checkoutSessionId =
+    typeof deposit.checkoutSessionId === 'string' ? deposit.checkoutSessionId : undefined;
+  const checkoutUrl = typeof deposit.checkoutUrl === 'string' ? deposit.checkoutUrl : undefined;
+  const createdAt = typeof deposit.createdAt === 'string' ? deposit.createdAt : undefined;
+  const updatedAt = typeof deposit.updatedAt === 'string' ? deposit.updatedAt : undefined;
+  const paidAt = typeof deposit.paidAt === 'string' ? deposit.paidAt : undefined;
+
+  return {
+    required,
+    status,
+    amount,
+    currency,
+    checkoutSessionId,
+    checkoutUrl,
+    createdAt,
+    updatedAt,
+    paidAt
+  };
+}
+
+function calculateDepositAmount(service: ServiceRow, settings: Partial<TenantSettings>) {
+  const price = toNumber(service.price);
+  if (!price || price <= 0) {
+    return 0;
+  }
+
+  const depositType = service.deposit_type ?? settings.defaultDepositType ?? 'percentage';
+  const rawValue =
+    service.deposit_value !== undefined && service.deposit_value !== null
+      ? toNumber(service.deposit_value)
+      : settings.defaultDepositValue ?? 0;
+
+  if (depositType === 'fixed') {
+    return roundCurrency(Math.max(0, Math.min(price, rawValue)));
+  }
+
+  const percentage = Math.max(0, rawValue);
+  const amount = (price * percentage) / 100;
+  return roundCurrency(Math.max(0, Math.min(price, amount)));
+}
+
+function getCheckoutUrls(env: Env) {
+  return {
+    successUrl: env.BOOKING_DEPOSIT_SUCCESS_URL ?? DEFAULT_CHECKOUT_SUCCESS_URL,
+    cancelUrl: env.BOOKING_DEPOSIT_CANCEL_URL ?? DEFAULT_CHECKOUT_CANCEL_URL
+  };
+}
+
+function getCurrency(env: Env) {
+  return (env.DEFAULT_CURRENCY ?? 'gbp').toLowerCase();
+}
+
 function mapBooking(row: BookingRow): Booking {
+  const metadata = (row.metadata ?? undefined) as Record<string, unknown> | undefined;
+  const deposit = parseDepositMetadata(metadata);
+
   return {
     id: row.id,
     tenantId: row.tenant_id,
@@ -40,12 +162,57 @@ function mapBooking(row: BookingRow): Booking {
     endTime: row.end_time ?? undefined,
     status: row.status as Booking['status'],
     notes: row.notes ?? undefined,
-    metadata: row.metadata ?? undefined,
+    metadata: metadata && Object.keys(metadata).length > 0 ? metadata : undefined,
+    deposit,
     createdBy: row.created_by,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
     cancelledAt: row.cancelled_at ?? undefined
   };
+}
+
+async function fetchService(client: ReturnType<typeof getClient>, tenantId: string, serviceId: string) {
+  const { data, error } = await client
+    .from('services')
+    .select('id, tenant_id, name, price, requires_deposit, deposit_type, deposit_value')
+    .eq('tenant_id', tenantId)
+    .eq('id', serviceId)
+    .single();
+
+  if (error || !data) {
+    throw new Error(`Failed to load service: ${error?.message ?? 'not found'}`);
+  }
+
+  return data as ServiceRow;
+}
+
+async function fetchTenantSettings(client: ReturnType<typeof getClient>, tenantId: string) {
+  const { data, error } = await client.from('tenants').select('settings').eq('id', tenantId).single();
+  if (error) {
+    throw new Error(`Failed to load tenant settings: ${error.message}`);
+  }
+
+  const settings = (data as TenantRow | null)?.settings ?? {};
+  return settings;
+}
+
+async function fetchClientContact(
+  client: ReturnType<typeof getClient>,
+  tenantId: string,
+  clientId: string
+) {
+  const { data, error } = await client
+    .from('clients')
+    .select('email, first_name, last_name')
+    .eq('tenant_id', tenantId)
+    .eq('id', clientId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to load client contact details: ${error.message}`);
+  }
+
+  return (data as ClientRow | null) ?? null;
 }
 
 export interface ListBookingsOptions {
@@ -72,14 +239,48 @@ export async function listBookings(env: Env, tenantId: string, options: ListBook
   return (data ?? []).map((row) => mapBooking(row as BookingRow));
 }
 
+export interface CreateBookingResult {
+  booking: Booking;
+  checkoutUrl?: string;
+}
+
 export async function createBooking(
   env: Env,
   tenantId: string,
   userId: string,
   input: BookingCreateInput
-) {
+): Promise<CreateBookingResult> {
   const client = getClient(env);
+  const [service, settings] = await Promise.all([
+    fetchService(client, tenantId, input.serviceId),
+    fetchTenantSettings(client, tenantId)
+  ]);
+
+  const depositsEnabled = Boolean(settings.depositsEnabled);
+  const currency = getCurrency(env);
+  let depositAmount = 0;
+  let depositRequired = false;
+
+  if (depositsEnabled && Boolean(service.requires_deposit)) {
+    depositAmount = calculateDepositAmount(service, settings);
+    depositRequired = depositAmount > 0;
+  }
+
   const now = new Date().toISOString();
+  const metadataBase = { ...(input.metadata ?? {}) } as Record<string, unknown>;
+
+  if (depositRequired) {
+    metadataBase.deposit = {
+      required: true,
+      status: 'pending',
+      amount: depositAmount,
+      currency,
+      createdAt: now,
+      updatedAt: now
+    } satisfies BookingDeposit;
+  }
+
+  const status = depositRequired ? 'pending' : input.status ?? 'pending';
   const insertPayload = {
     tenant_id: tenantId,
     client_id: input.clientId,
@@ -87,9 +288,9 @@ export async function createBooking(
     stylist_id: input.stylistId ?? null,
     start_time: input.startTime,
     end_time: input.endTime ?? null,
-    status: input.status ?? 'pending',
+    status,
     notes: input.notes ?? null,
-    metadata: input.metadata ?? null,
+    metadata: Object.keys(metadataBase).length > 0 ? metadataBase : null,
     created_by: userId,
     updated_at: now
   };
@@ -104,7 +305,81 @@ export async function createBooking(
     throw new Error(`Failed to create booking: ${error?.message ?? 'Unknown error'}`);
   }
 
-  return mapBooking(data as BookingRow);
+  let bookingRow = data as BookingRow;
+  let checkoutUrl: string | undefined;
+
+  if (depositRequired) {
+    const stripe = createStripeClient(env);
+    const { successUrl, cancelUrl } = getCheckoutUrls(env);
+    const contact = await fetchClientContact(client, tenantId, input.clientId);
+    const session = await stripe.createCheckoutSession({
+      amount: Math.round(depositAmount * 100),
+      currency,
+      clientReferenceId: bookingRow.id,
+      successUrl,
+      cancelUrl,
+      customerEmail: contact?.email ?? undefined,
+      productName: `${service.name} deposit`,
+      description: `Deposit for ${service.name}`,
+      metadata: {
+        tenantId,
+        bookingId: bookingRow.id,
+        serviceId: service.id,
+        clientId: input.clientId
+      }
+    });
+
+    checkoutUrl = session.url;
+
+    const timestamp = new Date().toISOString();
+    const metadata = (bookingRow.metadata ?? {}) as Record<string, unknown>;
+    const depositDetails = {
+      ...(typeof metadata.deposit === 'object' ? (metadata.deposit as Record<string, unknown>) : {}),
+      required: true,
+      status: 'pending',
+      amount: depositAmount,
+      currency,
+      checkoutSessionId: session.id,
+      checkoutUrl: session.url,
+      updatedAt: timestamp
+    } satisfies BookingDeposit;
+
+    if (!depositDetails.createdAt) {
+      depositDetails.createdAt = now;
+    }
+
+    metadata.deposit = depositDetails;
+
+    const { data: updated } = await client
+      .from('bookings')
+      .update({ metadata, updated_at: timestamp })
+      .eq('tenant_id', tenantId)
+      .eq('id', bookingRow.id)
+      .select(BOOKING_COLUMNS)
+      .single();
+
+    if (updated) {
+      bookingRow = updated as BookingRow;
+    }
+
+    await client.from('payment_transactions').insert({
+      id: crypto.randomUUID(),
+      tenant_id: tenantId,
+      appointment_id: null,
+      client_id: input.clientId,
+      amount: depositAmount,
+      currency,
+      status: 'requires_payment_method',
+      stripe_payment_intent_id: session.payment_intent ?? null,
+      metadata: {
+        type: 'deposit',
+        bookingId: bookingRow.id,
+        checkoutSessionId: session.id
+      }
+    });
+  }
+
+  return { booking: mapBooking(bookingRow), checkoutUrl };
 }
 
 export async function updateBooking(

--- a/workers/api/src/services/dashboard-service.ts
+++ b/workers/api/src/services/dashboard-service.ts
@@ -17,11 +17,58 @@ export async function getDashboardSummary(env: Env, tenantId: string) {
     .eq('tenant_id', tenantId)
     .eq('handled_by', 'human');
 
+  const pendingBookings = await client
+    .from('bookings')
+    .select('id')
+    .eq('tenant_id', tenantId)
+    .eq('status', 'pending');
+
+  if (pendingBookings.error) {
+    throw new Error(`Failed to load pending bookings: ${pendingBookings.error.message}`);
+  }
+
+  const { data: depositTransactions, error: depositError } = await client
+    .from('payment_transactions')
+    .select('amount, status, created_at')
+    .eq('tenant_id', tenantId)
+    .contains('metadata', { type: 'deposit' });
+
+  if (depositError) {
+    throw new Error(`Failed to load deposit transactions: ${depositError.message}`);
+  }
+
+  const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+  let pendingDeposits = 0;
+  let collectedDeposits = 0;
+  let revenueLast30d = 0;
+
+  for (const tx of depositTransactions ?? []) {
+    const status = typeof tx.status === 'string' ? tx.status : '';
+    const amountValue =
+      typeof tx.amount === 'number'
+        ? tx.amount
+        : typeof tx.amount === 'string'
+          ? Number.parseFloat(tx.amount)
+          : 0;
+    const createdAt = typeof tx.created_at === 'string' ? new Date(tx.created_at) : null;
+
+    if (status === 'succeeded') {
+      collectedDeposits += 1;
+      if (createdAt && createdAt >= thirtyDaysAgo) {
+        revenueLast30d += Number.isFinite(amountValue) ? amountValue : 0;
+      }
+    } else if (status === 'requires_payment_method' || status === 'requires_confirmation') {
+      pendingDeposits += 1;
+    }
+  }
+
   return {
     upcomingAppointments: upcoming.data?.length ?? 0,
-    pendingConfirmations: 0,
+    pendingConfirmations: pendingBookings.data?.length ?? 0,
     pendingMessages: pendingMessages.data?.length ?? 0,
-    revenueLast30d: 0
+    revenueLast30d,
+    pendingDeposits,
+    collectedDeposits
   };
 }
 

--- a/workers/api/src/services/payment-service.ts
+++ b/workers/api/src/services/payment-service.ts
@@ -5,6 +5,91 @@ function getClient(env: Env) {
   return createClient(env.SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY);
 }
 
+function toNumber(value: unknown) {
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') {
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function centsToMajor(value: unknown) {
+  const cents = toNumber(value);
+  if (cents === undefined) return undefined;
+  return Math.round(cents) / 100;
+}
+
+function coerceString(value: unknown) {
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return value;
+  }
+  return undefined;
+}
+
+async function mutateBookingDeposit(
+  client: ReturnType<typeof getClient>,
+  tenantId: string,
+  bookingId: string,
+  mutate: (context: {
+    deposit: Record<string, unknown>;
+    currentStatus: string;
+    timestamp: string;
+  }) => { deposit?: Record<string, unknown>; bookingStatus?: string }
+) {
+  const { data, error } = await client
+    .from('bookings')
+    .select('metadata, status')
+    .eq('tenant_id', tenantId)
+    .eq('id', bookingId)
+    .single();
+
+  if (error || !data) {
+    throw new Error(`Failed to load booking for deposit update: ${error?.message ?? 'not found'}`);
+  }
+
+  const metadata = ((data as { metadata?: Record<string, unknown> }).metadata ?? {}) as Record<string, unknown>;
+  const existingDeposit =
+    metadata && typeof metadata.deposit === 'object' && metadata.deposit !== null
+      ? { ...(metadata.deposit as Record<string, unknown>) }
+      : {};
+
+  const timestamp = new Date().toISOString();
+  const result = mutate({
+    deposit: existingDeposit,
+    currentStatus: (data as { status: string }).status,
+    timestamp
+  });
+
+  const updatedDeposit = {
+    ...existingDeposit,
+    ...(result.deposit ?? {}),
+    updatedAt: timestamp
+  };
+
+  if (!updatedDeposit.createdAt && typeof existingDeposit.createdAt === 'string') {
+    updatedDeposit.createdAt = existingDeposit.createdAt;
+  } else if (!updatedDeposit.createdAt) {
+    updatedDeposit.createdAt = timestamp;
+  }
+
+  metadata.deposit = updatedDeposit;
+
+  const bookingStatus = result.bookingStatus ?? (data as { status: string }).status;
+
+  const { error: updateError } = await client
+    .from('bookings')
+    .update({ metadata, status: bookingStatus, updated_at: timestamp })
+    .eq('tenant_id', tenantId)
+    .eq('id', bookingId);
+
+  if (updateError) {
+    throw new Error(`Failed to update booking record: ${updateError.message}`);
+  }
+
+  return { deposit: updatedDeposit, timestamp, bookingStatus };
+}
+
 export async function createDepositIntent(env: Env, tenantId: string, payload: any) {
   const stripe = createStripeClient(env);
   const amount = Math.round((payload.amount ?? 0) * 100);
@@ -32,4 +117,114 @@ export async function listTransactions(env: Env, tenantId: string) {
     throw new Error(`Failed to fetch transactions: ${error.message}`);
   }
   return data ?? [];
+}
+
+export async function handleStripeEvent(env: Env, event: Record<string, unknown>) {
+  if (!event || typeof event !== 'object') {
+    console.warn('Received invalid Stripe event payload');
+    return { handled: false };
+  }
+
+  const client = getClient(env);
+  const eventType = coerceString(event.type);
+
+  if (!eventType) {
+    return { handled: false };
+  }
+
+  const session = (event.data as { object?: Record<string, unknown> } | undefined)?.object;
+
+  if (eventType === 'checkout.session.completed') {
+    if (!session) return { handled: false };
+    const metadata = (session.metadata as Record<string, unknown> | undefined) ?? {};
+    const tenantId = coerceString(metadata.tenantId ?? metadata.tenant_id);
+    const bookingId = coerceString(session.client_reference_id);
+
+    if (!tenantId || !bookingId) {
+      console.warn('Stripe checkout session missing tenant or booking reference');
+      return { handled: false };
+    }
+
+    const { timestamp } = await mutateBookingDeposit(client, tenantId, bookingId, ({ deposit, timestamp }) => {
+      deposit.required = true;
+      deposit.status = 'paid';
+      const amount = centsToMajor(session.amount_total ?? session.amount_subtotal);
+      if (amount !== undefined) {
+        deposit.amount = amount;
+      }
+      const currency = coerceString(session.currency);
+      if (currency) {
+        deposit.currency = currency;
+      }
+      const sessionId = coerceString(session.id);
+      if (sessionId) {
+        deposit.checkoutSessionId = sessionId;
+      }
+      const sessionUrl = coerceString(session.url);
+      if (sessionUrl) {
+        deposit.checkoutUrl = sessionUrl;
+      }
+      deposit.paidAt = timestamp;
+      return { deposit, bookingStatus: 'confirmed' };
+    });
+
+    const paymentIntentId = coerceString(session.payment_intent);
+    const { error: txError } = await client
+      .from('payment_transactions')
+      .update({
+        status: 'succeeded',
+        stripe_payment_intent_id: paymentIntentId ?? null,
+        updated_at: timestamp
+      })
+      .eq('tenant_id', tenantId)
+      .contains('metadata', { bookingId });
+
+    if (txError) {
+      throw new Error(`Failed to update payment transaction: ${txError.message}`);
+    }
+
+    return { handled: true };
+  }
+
+  if (eventType === 'checkout.session.expired' || eventType === 'checkout.session.async_payment_failed') {
+    if (!session) return { handled: false };
+    const metadata = (session.metadata as Record<string, unknown> | undefined) ?? {};
+    const tenantId = coerceString(metadata.tenantId ?? metadata.tenant_id);
+    const bookingId = coerceString(session.client_reference_id);
+
+    if (!tenantId || !bookingId) {
+      console.warn('Stripe checkout session failure missing identifiers');
+      return { handled: false };
+    }
+
+    const depositStatus = eventType === 'checkout.session.expired' ? 'cancelled' : 'failed';
+    const { timestamp } = await mutateBookingDeposit(client, tenantId, bookingId, ({ deposit }) => {
+      deposit.required = true;
+      deposit.status = depositStatus;
+      const sessionId = coerceString(session.id);
+      if (sessionId) {
+        deposit.checkoutSessionId = sessionId;
+      }
+      const sessionUrl = coerceString(session.url);
+      if (sessionUrl) {
+        deposit.checkoutUrl = sessionUrl;
+      }
+      return { deposit };
+    });
+
+    const txStatus = depositStatus === 'cancelled' ? 'cancelled' : 'failed';
+    const { error: txError } = await client
+      .from('payment_transactions')
+      .update({ status: txStatus, updated_at: timestamp })
+      .eq('tenant_id', tenantId)
+      .contains('metadata', { bookingId });
+
+    if (txError) {
+      throw new Error(`Failed to update payment transaction after ${depositStatus}: ${txError.message}`);
+    }
+
+    return { handled: true };
+  }
+
+  return { handled: false };
 }

--- a/workers/api/src/types/env.d.ts
+++ b/workers/api/src/types/env.d.ts
@@ -8,6 +8,9 @@ interface Env {
   TWILIO_ACCOUNT_SID: string;
   TWILIO_AUTH_TOKEN: string;
   OPENAI_API_KEY: string;
+  BOOKING_DEPOSIT_SUCCESS_URL?: string;
+  BOOKING_DEPOSIT_CANCEL_URL?: string;
+  DEFAULT_CURRENCY?: string;
   SUPABASE_DB_HOST?: string;
   SUPABASE_DB_NAME?: string;
   SUPABASE_DB_USER?: string;


### PR DESCRIPTION
## Summary
- add per-service deposit metadata and create Stripe Checkout sessions during booking creation when deposits are enabled
- process Stripe webhooks to reconcile deposit payments and update booking/payment transaction status
- expose deposit settings in shared types, update schema, and surface deposit metrics on the admin dashboard

## Testing
- npm run test *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e44386611083299842be65ad2cc383