### PR TITLE
feat: add subscription plans and feature gating

### DIFF
--- a/apps/web/lib/feature-flags.tsx
+++ b/apps/web/lib/feature-flags.tsx
@@ -1,0 +1,67 @@
+import { createContext, PropsWithChildren, useCallback, useContext, useMemo } from 'react';
+import useSWR from 'swr';
+import type {
+  FeatureCode,
+  PlanSummary,
+  TenantPlanAccess,
+  TenantPlanResponse
+} from '@ai-hairdresser/shared';
+import { apiFetch } from './api-client';
+
+const FeatureFlagContext = createContext<FeatureContextValue | undefined>(undefined);
+
+const fetcher = (path: string) => apiFetch<TenantPlanResponse>(path);
+
+type FeatureContextValue = {
+  loading: boolean;
+  error?: string;
+  plan?: TenantPlanAccess;
+  availablePlans: PlanSummary[];
+  features: FeatureCode[];
+  hasFeature: (feature: FeatureCode) => boolean;
+  refresh: () => Promise<TenantPlanResponse | undefined>;
+};
+
+export function FeatureFlagProvider({ children }: PropsWithChildren) {
+  const { data, error, isLoading, mutate } = useSWR('/tenants/plan', fetcher, {
+    revalidateOnFocus: false
+  });
+
+  const refresh = useCallback(() => mutate(), [mutate]);
+
+  const value = useMemo<FeatureContextValue>(() => {
+    const plan = data?.tenantPlan;
+    const availablePlans = data?.availablePlans ?? [];
+    const features = plan?.features ?? [];
+    const featureSet = new Set(features);
+
+    return {
+      loading: Boolean(isLoading),
+      error: error instanceof Error ? error.message : undefined,
+      plan,
+      availablePlans,
+      features,
+      hasFeature: (feature: FeatureCode) => featureSet.has(feature),
+      refresh
+    };
+  }, [data, error, isLoading, refresh]);
+
+  return <FeatureFlagContext.Provider value={value}>{children}</FeatureFlagContext.Provider>;
+}
+
+export function useFeatureFlags() {
+  const context = useContext(FeatureFlagContext);
+  if (!context) {
+    throw new Error('useFeatureFlags must be used within FeatureFlagProvider');
+  }
+  return context;
+}
+
+export function useFeatureFlag(feature: FeatureCode) {
+  const context = useFeatureFlags();
+  return {
+    enabled: context.hasFeature(feature),
+    loading: context.loading,
+    plan: context.plan
+  };
+}

--- a/apps/web/pages/_app.tsx
+++ b/apps/web/pages/_app.tsx
@@ -1,11 +1,14 @@
 import type { AppProps } from 'next/app';
 import { SupabaseProvider } from '@/lib/supabase-provider';
+import { FeatureFlagProvider } from '@/lib/feature-flags';
 import '@/styles/globals.css';
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
     <SupabaseProvider>
-      <Component {...pageProps} />
+      <FeatureFlagProvider>
+        <Component {...pageProps} />
+      </FeatureFlagProvider>
     </SupabaseProvider>
   );
 }

--- a/apps/web/pages/admin/plan.tsx
+++ b/apps/web/pages/admin/plan.tsx
@@ -1,0 +1,175 @@
+import { useState } from 'react';
+import Head from 'next/head';
+import type { FeatureCode, PlanSummary } from '@ai-hairdresser/shared';
+import { apiFetch } from '@/lib/api-client';
+import { useFeatureFlags } from '@/lib/feature-flags';
+
+export default function PlanAdminPage() {
+  const { plan, availablePlans, loading, error, refresh } = useFeatureFlags();
+  const [updating, setUpdating] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const currentCode = plan?.plan.code;
+  const effectiveCode = plan?.effectivePlan.code;
+  const effectiveName = plan?.effectivePlan.name;
+  const downgraded = Boolean(plan && plan.downgradedTo && plan.downgradedTo.code !== plan.plan.code);
+
+  async function handleSelect(target: PlanSummary) {
+    setUpdating(target.code);
+    setMessage(null);
+    setSubmitError(null);
+    try {
+      await apiFetch('/tenants/plan', {
+        method: 'POST',
+        body: { planCode: target.code }
+      });
+      await refresh();
+      setMessage(`Plan updated to ${target.name}`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unable to update plan';
+      setSubmitError(message);
+    } finally {
+      setUpdating(null);
+    }
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Subscription &amp; billing | AI Hairdresser Receptionist</title>
+      </Head>
+      <main className="billing">
+        <header>
+          <div>
+            <h1>Subscription &amp; billing</h1>
+            {plan && (
+              <p>
+                Current plan: <strong>{plan.plan.name}</strong>
+                {plan.isInGracePeriod && plan.gracePeriodEndsAt && (
+                  <> (grace period ends {new Date(plan.gracePeriodEndsAt).toLocaleDateString()})</>
+                )}
+              </p>
+            )}
+            {downgraded && effectiveName && (
+              <p className="warning">
+                Your subscription reverted to {effectiveName}. Reactivate billing to regain premium features.
+              </p>
+            )}
+          </div>
+        </header>
+        {error && <p className="error">Failed to load plan information.</p>}
+        {message && <p className="success">{message}</p>}
+        {submitError && <p className="error">{submitError}</p>}
+        {loading && <p>Loading available plans…</p>}
+        {!loading && (
+          <section className="plans">
+            {availablePlans.map((tier) => {
+              const isCurrent = tier.code === currentCode;
+              const isEffective = tier.code === effectiveCode;
+              const disabled = updating !== null || isCurrent;
+              const cta = isCurrent ? 'Current plan' : isEffective ? 'In use' : 'Select plan';
+              return (
+                <article key={tier.code} className={isEffective ? 'active' : ''}>
+                  <header>
+                    <h2>{tier.name}</h2>
+                    <p className="price">
+                      {tier.monthlyPrice ? `£${tier.monthlyPrice.toFixed(0)}/mo` : 'Free'}
+                    </p>
+                  </header>
+                  {tier.description && <p className="description">{tier.description}</p>}
+                  <ul>
+                    {tier.features.map((feature) => (
+                      <li key={feature}>{renderFeature(feature)}</li>
+                    ))}
+                    {!tier.features.length && <li>Core messaging &amp; calendar tools</li>}
+                  </ul>
+                  <button
+                    disabled={disabled}
+                    onClick={() => handleSelect(tier)}
+                    aria-disabled={disabled}
+                  >
+                    {updating === tier.code ? 'Updating…' : cta}
+                  </button>
+                </article>
+              );
+            })}
+          </section>
+        )}
+      </main>
+      <style jsx>{`
+        .billing {
+          padding: 2rem 3rem;
+        }
+        header {
+          margin-bottom: 2rem;
+        }
+        .plans {
+          display: grid;
+          gap: 1.5rem;
+          grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+        }
+        article {
+          border-radius: 16px;
+          background: #ffffff;
+          padding: 1.75rem;
+          box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);
+          display: flex;
+          flex-direction: column;
+          gap: 1rem;
+        }
+        article.active {
+          border: 2px solid #38bdf8;
+        }
+        article header {
+          display: flex;
+          justify-content: space-between;
+          align-items: baseline;
+          gap: 1rem;
+        }
+        .price {
+          font-size: 1.25rem;
+          font-weight: 600;
+        }
+        ul {
+          margin: 0;
+          padding-left: 1.25rem;
+          flex: 1;
+        }
+        button {
+          align-self: flex-start;
+          border-radius: 8px;
+          border: none;
+          background: #2563eb;
+          color: #fff;
+          padding: 0.5rem 1.5rem;
+          cursor: pointer;
+        }
+        button[disabled],
+        button[aria-disabled='true'] {
+          opacity: 0.6;
+          cursor: not-allowed;
+        }
+        .error {
+          color: #dc2626;
+        }
+        .success {
+          color: #047857;
+        }
+        .warning {
+          color: #d97706;
+        }
+      `}</style>
+    </>
+  );
+}
+
+const featureLabels: Record<FeatureCode, string> = {
+  deposits_enabled: 'Deposits & secure online payments',
+  ai_assistant_enabled: 'AI assistant for inbound messages',
+  team_accounts: 'Team accounts & rota management'
+};
+
+function renderFeature(feature: FeatureCode) {
+  return featureLabels[feature] ?? feature;
+}

--- a/apps/web/pages/api/tenants/plan.ts
+++ b/apps/web/pages/api/tenants/plan.ts
@@ -1,0 +1,39 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { withTenantContext } from '@/lib/with-tenant-context';
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET' && req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  try {
+    const target = `${process.env.NEXT_PUBLIC_API_BASE_URL ?? ''}/tenants/me/plan`;
+    const headers: Record<string, string> = {
+      Authorization: (req.headers.authorization as string) ?? '',
+      'x-tenant-id': req.headers['x-tenant-id'] as string,
+      'x-platform-origin': 'next-web'
+    };
+
+    if (req.method === 'POST') {
+      headers['Content-Type'] = 'application/json';
+    }
+
+    const response = await fetch(target, {
+      method: req.method,
+      headers,
+      body: req.method === 'POST' ? JSON.stringify(req.body ?? {}) : undefined
+    });
+
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      return res.status(response.status).json({ error: payload.error ?? 'Unable to process request', details: payload.details });
+    }
+
+    return res.status(response.status).json(payload);
+  } catch (error) {
+    console.error('Tenant plan proxy error', error);
+    return res.status(500).json({ error: 'Unexpected error' });
+  }
+}
+
+export default withTenantContext(handler);

--- a/apps/web/pages/dashboard/index.tsx
+++ b/apps/web/pages/dashboard/index.tsx
@@ -2,6 +2,7 @@ import useSWR from 'swr';
 import Link from 'next/link';
 import Head from 'next/head';
 import { apiFetch } from '@/lib/api-client';
+import { useFeatureFlag } from '@/lib/feature-flags';
 
 type DashboardSummary = {
   upcomingAppointments: number;
@@ -16,6 +17,8 @@ const fetcher = (path: string) => apiFetch<DashboardSummary>(path);
 
 export default function DashboardPage() {
   const { data, error } = useSWR('/dashboard/summary', fetcher);
+  const depositsFeature = useFeatureFlag('deposits_enabled');
+  const teamFeature = useFeatureFlag('team_accounts');
 
   return (
     <>
@@ -30,9 +33,10 @@ export default function DashboardPage() {
             <Link href="/dashboard/inbox">Inbox</Link>
             <Link href="/appointments">Appointments</Link>
             <Link href="/clients">Clients</Link>
-            <Link href="/stylists">Stylists</Link>
+            {(teamFeature.loading || teamFeature.enabled) && <Link href="/stylists">Stylists</Link>}
             <Link href="/admin/monitoring">Monitoring</Link>
             <Link href="/admin/marketing">Marketing Studio</Link>
+            <Link href="/admin/plan">Subscription &amp; billing</Link>
           </nav>
         </aside>
         <section className="content">
@@ -57,14 +61,29 @@ export default function DashboardPage() {
                 <h2>Revenue (30d)</h2>
                 <p>£{data.revenueLast30d?.toFixed(2)}</p>
               </article>
-              <article>
-                <h2>Deposits pending</h2>
-                <p>{data.pendingDeposits}</p>
-              </article>
-              <article>
-                <h2>Deposits collected</h2>
-                <p>{data.collectedDeposits}</p>
-              </article>
+              {depositsFeature.enabled ? (
+                <>
+                  <article>
+                    <h2>Deposits pending</h2>
+                    <p>{data.pendingDeposits}</p>
+                  </article>
+                  <article>
+                    <h2>Deposits collected</h2>
+                    <p>{data.collectedDeposits}</p>
+                  </article>
+                </>
+              ) : (
+                !depositsFeature.loading && (
+                  <article className="locked">
+                    <h2>Deposits insights</h2>
+                    <p>
+                      Upgrade your plan to unlock deposit tracking and payment automation. Visit
+                      {' '}
+                      <Link href="/admin/plan">Subscription &amp; billing</Link> to compare tiers.
+                    </p>
+                  </article>
+                )
+              )}
             </div>
           )}
         </section>
@@ -103,6 +122,10 @@ export default function DashboardPage() {
           padding: 1.5rem;
           border-radius: 12px;
           box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);
+        }
+        .locked {
+          background: #f1f5f9;
+          color: #475569;
         }
         .error {
           color: #dc2626;

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -12,3 +12,6 @@ export const AUDIT_RESOURCE_TYPES = [
   'message',
   'payment'
 ] as const;
+
+export const FEATURE_CODES = ['deposits_enabled', 'ai_assistant_enabled', 'team_accounts'] as const;
+export const PLAN_CODES = ['free', 'basic', 'pro'] as const;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -3,6 +3,10 @@ export type UserId = string;
 export type AppointmentId = string;
 export type BookingId = string;
 
+export type FeatureCode = 'deposits_enabled' | 'ai_assistant_enabled' | 'team_accounts';
+export type PlanCode = 'free' | 'basic' | 'pro';
+export type TenantPlanStatus = 'trialing' | 'active' | 'past_due' | 'cancelled' | 'expired';
+
 export interface Tenant {
   id: TenantId;
   name: string;
@@ -203,4 +207,31 @@ export interface CalendarSyncToken {
   googleCalendarId: string;
   syncToken: string;
   updatedAt: string;
+}
+
+export interface PlanSummary {
+  code: PlanCode;
+  name: string;
+  description?: string | null;
+  monthlyPrice?: number | null;
+  currency?: string | null;
+  gracePeriodDays: number;
+  features: FeatureCode[];
+}
+
+export interface TenantPlanAccess {
+  plan: PlanSummary;
+  effectivePlan: PlanSummary;
+  status: TenantPlanStatus;
+  billingStatus?: string | null;
+  features: FeatureCode[];
+  isInGracePeriod: boolean;
+  currentPeriodEnd?: string | null;
+  gracePeriodEndsAt?: string | null;
+  downgradedTo?: PlanSummary | null;
+}
+
+export interface TenantPlanResponse {
+  tenantPlan: TenantPlanAccess;
+  availablePlans: PlanSummary[];
 }

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -137,6 +137,52 @@ create table if not exists payment_transactions (
   updated_at timestamp with time zone default timezone('utc', now())
 );
 
+create table if not exists plans (
+  id uuid primary key default uuid_generate_v4(),
+  code text unique not null,
+  name text not null,
+  description text,
+  monthly_price numeric(10,2),
+  currency text default 'gbp',
+  grace_period_days integer default 7,
+  is_active boolean default true,
+  metadata jsonb default '{}'::jsonb,
+  created_at timestamp with time zone default timezone('utc', now()),
+  updated_at timestamp with time zone default timezone('utc', now())
+);
+
+create table if not exists features (
+  code text primary key,
+  name text not null,
+  description text,
+  created_at timestamp with time zone default timezone('utc', now())
+);
+
+create table if not exists plan_features (
+  plan_id uuid references plans(id) on delete cascade,
+  feature_code text references features(code) on delete cascade,
+  created_at timestamp with time zone default timezone('utc', now()),
+  primary key (plan_id, feature_code)
+);
+
+create table if not exists tenant_plans (
+  id uuid primary key default uuid_generate_v4(),
+  tenant_id uuid references tenants(id) on delete cascade,
+  plan_id uuid references plans(id) on delete set null,
+  status text not null check (status in ('trialing','active','past_due','cancelled','expired')) default 'active',
+  billing_status text,
+  billing_provider text,
+  billing_reference text,
+  current_period_start timestamp with time zone default timezone('utc', now()),
+  current_period_end timestamp with time zone,
+  grace_period_ends_at timestamp with time zone,
+  cancel_at timestamp with time zone,
+  created_at timestamp with time zone default timezone('utc', now()),
+  updated_at timestamp with time zone default timezone('utc', now())
+);
+
+create index if not exists tenant_plans_tenant_idx on tenant_plans (tenant_id, created_at desc);
+
 create table if not exists audit_logs (
   id uuid primary key,
   tenant_id uuid references tenants(id) on delete cascade,
@@ -179,6 +225,7 @@ alter table payment_transactions enable row level security;
 alter table audit_logs enable row level security;
 alter table usage_metrics enable row level security;
 alter table calendar_sync_tokens enable row level security;
+alter table tenant_plans enable row level security;
 
 -- Policies
 create policy if not exists "tenants_isolation" on tenants
@@ -245,3 +292,46 @@ create policy if not exists "audit_isolation" on audit_logs
 
 create policy if not exists "metrics_isolation" on usage_metrics
   for select using (tenant_id = get_auth_tenant_id());
+
+create policy if not exists "tenant_plans_isolation" on tenant_plans
+  for select using (tenant_id = get_auth_tenant_id());
+
+create policy if not exists "tenant_plans_mutation" on tenant_plans
+  for all using (tenant_id = get_auth_tenant_id()) with check (tenant_id = get_auth_tenant_id());
+
+insert into features (code, name, description)
+values
+  ('deposits_enabled', 'Deposits & Payments', 'Collect booking deposits and payment intents'),
+  ('ai_assistant_enabled', 'AI Assistant', 'Access AI-generated responses and automations'),
+  ('team_accounts', 'Team Accounts', 'Invite and manage team members')
+on conflict (code) do update set
+  name = excluded.name,
+  description = excluded.description;
+
+insert into plans (code, name, description, monthly_price, currency, grace_period_days, is_active)
+values
+  ('free', 'Free', 'Core receptionist tools for solo stylists', 0, 'gbp', 7, true),
+  ('basic', 'Basic', 'Deposits and team collaboration toolkit', 49, 'gbp', 10, true),
+  ('pro', 'Pro', 'Full AI automation suite with premium support', 99, 'gbp', 14, true)
+on conflict (code) do update set
+  name = excluded.name,
+  description = excluded.description,
+  monthly_price = excluded.monthly_price,
+  currency = excluded.currency,
+  grace_period_days = excluded.grace_period_days,
+  is_active = excluded.is_active,
+  updated_at = timezone('utc', now());
+
+insert into plan_features (plan_id, feature_code)
+select p.id, f.code
+from plans p
+join features f on f.code in ('team_accounts', 'deposits_enabled')
+where p.code = 'basic'
+on conflict do nothing;
+
+insert into plan_features (plan_id, feature_code)
+select p.id, f.code
+from plans p
+join features f on f.code in ('team_accounts', 'deposits_enabled', 'ai_assistant_enabled')
+where p.code = 'pro'
+on conflict do nothing;

--- a/workers/api/src/index.ts
+++ b/workers/api/src/index.ts
@@ -14,6 +14,7 @@ import { withTenant } from './middleware/tenant';
 import { withAuth } from './middleware/auth';
 import { bookingRouter } from './routes/bookings';
 import { assistRouter } from './routes/assist';
+import { withFeatureFlags } from './middleware/features';
 
 const router = Router();
 
@@ -56,6 +57,12 @@ async function handleRequest(request: Request, env: Env, ctx: ExecutionContext) 
     return authResult;
   }
   scoped = authResult;
+
+  const featuresResult = await withFeatureFlags(scoped, env, ctx);
+  if (featuresResult instanceof Response) {
+    return featuresResult;
+  }
+  scoped = featuresResult;
 
   return router.handle(scoped, env, ctx);
 }

--- a/workers/api/src/middleware/features.ts
+++ b/workers/api/src/middleware/features.ts
@@ -1,0 +1,41 @@
+import type { FeatureCode } from '@ai-hairdresser/shared';
+import { JsonResponse } from '../lib/response';
+import { getTenantPlanAccess, listPlans } from '../services/plan-service';
+
+const PUBLIC_PATHS = [/^\/healthz$/, /^\/auth\//, /^\/webhooks\//];
+
+const FEATURE_REQUIREMENTS: Array<{ pattern: RegExp; feature: FeatureCode }> = [
+  { pattern: /^\/assist(\/|$)/, feature: 'ai_assistant_enabled' },
+  { pattern: /^\/payments(\/|$)/, feature: 'deposits_enabled' },
+  { pattern: /^\/stylists(\/|$)/, feature: 'team_accounts' }
+];
+
+export async function withFeatureFlags(request: TenantScopedRequest, env: Env, _ctx: ExecutionContext) {
+  const url = new URL(request.url);
+  if (!request.tenantId || PUBLIC_PATHS.some((pattern) => pattern.test(url.pathname))) {
+    return request;
+  }
+
+  const featureAccess = await getTenantPlanAccess(env, request.tenantId);
+  request.featureAccess = featureAccess;
+  request.hasFeature = (feature: FeatureCode) => featureAccess.features.includes(feature);
+
+  const requirement = FEATURE_REQUIREMENTS.find((rule) => rule.pattern.test(url.pathname));
+  if (requirement && !request.hasFeature(requirement.feature)) {
+    return JsonResponse.error('Feature not available on current plan', 403, {
+      requiredFeature: requirement.feature,
+      activePlan: featureAccess.plan,
+      effectivePlan: featureAccess.effectivePlan
+    });
+  }
+
+  return request;
+}
+
+export async function getPlanOverview(env: Env, tenantId: string) {
+  const [tenantPlan, availablePlans] = await Promise.all([
+    getTenantPlanAccess(env, tenantId),
+    listPlans(env)
+  ]);
+  return { tenantPlan, availablePlans };
+}

--- a/workers/api/src/routes/tenants.ts
+++ b/workers/api/src/routes/tenants.ts
@@ -1,6 +1,9 @@
 import { Router } from 'itty-router';
+import { z } from 'zod';
 import { JsonResponse } from '../lib/response';
 import { getTenantById, listTenantUsers } from '../services/tenant-service';
+import { assignTenantPlan } from '../services/plan-service';
+import { getPlanOverview } from '../middleware/features';
 
 const router = Router({ base: '/tenants' });
 
@@ -12,6 +15,31 @@ router.get('/me', async (request: TenantScopedRequest, env: Env) => {
 router.get('/me/users', async (request: TenantScopedRequest, env: Env) => {
   const users = await listTenantUsers(env, request.tenantId!);
   return JsonResponse.ok({ users });
+});
+
+router.get('/me/plan', async (request: TenantScopedRequest, env: Env) => {
+  const overview = await getPlanOverview(env, request.tenantId!);
+  return JsonResponse.ok(overview);
+});
+
+const planUpdateSchema = z.object({
+  planCode: z.enum(['free', 'basic', 'pro'])
+});
+
+router.post('/me/plan', async (request: TenantScopedRequest, env: Env) => {
+  if (request.role && request.role !== 'admin') {
+    return JsonResponse.error('Only administrators can change plans', 403);
+  }
+
+  const body = await request.json().catch(() => null);
+  const parsed = planUpdateSchema.safeParse(body);
+  if (!parsed.success) {
+    return JsonResponse.error('Invalid payload', 400, parsed.error.flatten());
+  }
+
+  await assignTenantPlan(env, request.tenantId!, parsed.data.planCode);
+  const overview = await getPlanOverview(env, request.tenantId!);
+  return JsonResponse.ok(overview, { status: 202 });
 });
 
 export const tenantRouter = router;

--- a/workers/api/src/services/plan-service.ts
+++ b/workers/api/src/services/plan-service.ts
@@ -1,0 +1,185 @@
+import { createClient } from '@supabase/supabase-js';
+import type {
+  FeatureCode,
+  PlanCode,
+  PlanSummary,
+  TenantPlanAccess,
+  TenantPlanStatus
+} from '@ai-hairdresser/shared';
+
+function getClient(env: Env) {
+  return createClient(env.SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY);
+}
+
+function normalizePrice(value: unknown) {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') {
+    const parsed = Number.parseFloat(value);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+  return null;
+}
+
+function mapPlanRow(row: any): PlanSummary {
+  const features = Array.isArray(row.plan_features)
+    ? (row.plan_features
+        .map((feature: any) => feature?.feature_code)
+        .filter((code: unknown): code is FeatureCode => typeof code === 'string') as FeatureCode[])
+    : [];
+
+  return {
+    code: row.code,
+    name: row.name,
+    description: row.description ?? null,
+    monthlyPrice: normalizePrice(row.monthly_price),
+    currency: row.currency ?? null,
+    gracePeriodDays: typeof row.grace_period_days === 'number' ? row.grace_period_days : Number(row.grace_period_days ?? 0) || 0,
+    features
+  };
+}
+
+async function getPlanByCode(env: Env, code: PlanCode): Promise<PlanSummary> {
+  const client = getClient(env);
+  const { data, error } = await client
+    .from('plans')
+    .select('id, code, name, description, monthly_price, currency, grace_period_days, plan_features(feature_code)')
+    .eq('code', code)
+    .eq('is_active', true)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to load plan ${code}: ${error.message}`);
+  }
+
+  if (!data) {
+    throw new Error(`Plan ${code} is not configured`);
+  }
+
+  return mapPlanRow(data);
+}
+
+export async function listPlans(env: Env): Promise<PlanSummary[]> {
+  const client = getClient(env);
+  const { data, error } = await client
+    .from('plans')
+    .select('id, code, name, description, monthly_price, currency, grace_period_days, plan_features(feature_code)')
+    .eq('is_active', true)
+    .order('monthly_price', { ascending: true });
+
+  if (error) {
+    throw new Error(`Failed to list plans: ${error.message}`);
+  }
+
+  return (data ?? []).map(mapPlanRow);
+}
+
+function isActiveStatus(status: TenantPlanStatus) {
+  return status === 'active' || status === 'trialing';
+}
+
+export async function getTenantPlanAccess(env: Env, tenantId: string): Promise<TenantPlanAccess> {
+  const client = getClient(env);
+  const { data, error } = await client
+    .from('tenant_plans')
+    .select(
+      'id, status, billing_status, current_period_end, grace_period_ends_at, plan:plans(id, code, name, description, monthly_price, currency, grace_period_days, plan_features(feature_code))'
+    )
+    .eq('tenant_id', tenantId)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to resolve tenant plan: ${error.message}`);
+  }
+
+  const freePlan = await getPlanByCode(env, 'free');
+
+  if (!data?.plan) {
+    return {
+      plan: freePlan,
+      effectivePlan: freePlan,
+      status: 'active',
+      billingStatus: null,
+      features: freePlan.features,
+      isInGracePeriod: false,
+      currentPeriodEnd: null,
+      gracePeriodEndsAt: null,
+      downgradedTo: null
+    };
+  }
+
+  const plan = mapPlanRow({ ...data.plan, plan_features: data.plan.plan_features });
+  const status = (data.status ?? 'active') as TenantPlanStatus;
+  const currentPeriodEnd = data.current_period_end ?? null;
+  const gracePeriodEndsAt = data.grace_period_ends_at ?? null;
+
+  let isInGracePeriod = false;
+  if (gracePeriodEndsAt) {
+    const graceDate = new Date(gracePeriodEndsAt);
+    isInGracePeriod = Number.isFinite(graceDate.getTime()) && graceDate.getTime() > Date.now();
+  }
+
+  let effectivePlan = plan;
+  let downgradedTo: PlanSummary | null = null;
+
+  if (!isActiveStatus(status)) {
+    if (status === 'past_due' && isInGracePeriod) {
+      // still allow features during grace period
+      effectivePlan = plan;
+    } else {
+      effectivePlan = freePlan;
+      downgradedTo = freePlan;
+    }
+  }
+
+  return {
+    plan,
+    effectivePlan,
+    status,
+    billingStatus: data.billing_status ?? null,
+    features: effectivePlan.features,
+    isInGracePeriod,
+    currentPeriodEnd,
+    gracePeriodEndsAt,
+    downgradedTo
+  };
+}
+
+export async function assignTenantPlan(env: Env, tenantId: string, planCode: PlanCode) {
+  const client = getClient(env);
+  const plan = await getPlanByCode(env, planCode);
+  const now = new Date();
+  const currentPeriodEnd = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000);
+  const graceDays = Number.isFinite(plan.gracePeriodDays) ? plan.gracePeriodDays : 7;
+  const gracePeriodEnds = new Date(currentPeriodEnd.getTime() + graceDays * 24 * 60 * 60 * 1000);
+
+  const timestamp = now.toISOString();
+  const { data, error } = await client
+    .from('plans')
+    .select('id')
+    .eq('code', planCode)
+    .maybeSingle();
+
+  if (error || !data) {
+    throw new Error(`Unable to locate plan for assignment: ${error?.message ?? 'not found'}`);
+  }
+
+  const { error: insertError } = await client.from('tenant_plans').insert({
+    tenant_id: tenantId,
+    plan_id: data.id,
+    status: 'active',
+    billing_status: 'active',
+    current_period_start: timestamp,
+    current_period_end: currentPeriodEnd.toISOString(),
+    grace_period_ends_at: gracePeriodEnds.toISOString(),
+    updated_at: timestamp
+  });
+
+  if (insertError) {
+    throw new Error(`Failed to assign tenant plan: ${insertError.message}`);
+  }
+
+  return getTenantPlanAccess(env, tenantId);
+}

--- a/workers/api/src/types/env.d.ts
+++ b/workers/api/src/types/env.d.ts
@@ -1,3 +1,5 @@
+import type { FeatureCode, TenantPlanAccess } from '@ai-hairdresser/shared';
+
 interface Env {
   SUPABASE_URL: string;
   SUPABASE_SERVICE_ROLE_KEY: string;
@@ -23,4 +25,6 @@ type TenantScopedRequest = Request & {
   tenantId?: string;
   userId?: string;
   role?: string;
+  featureAccess?: TenantPlanAccess;
+  hasFeature?: (feature: FeatureCode) => boolean;
 };


### PR DESCRIPTION
## Summary
- add plans, features, and tenant_plans tables plus seed data and policies
- expose plan metadata via new worker service and middleware that enforces feature access
- surface feature flags in the Next app with a subscription admin page and gated UI navigation

## Testing
- npm test *(fails: upstream fixture hits api.example.com during POST method test)*

------
https://chatgpt.com/codex/tasks/task_e_68e4524ce0488329a606e74f0eeaaf66