### PR TITLE
Implement tenant usage tracking and quotas

### DIFF
--- a/apps/web/pages/admin/monitoring.tsx
+++ b/apps/web/pages/admin/monitoring.tsx
@@ -1,17 +1,31 @@
 import useSWR from 'swr';
 import Head from 'next/head';
+import { UsageOverview } from '@ai-hairdresser/shared';
 import { useTenant } from '@/hooks/useTenant';
 import { apiFetch } from '@/lib/api-client';
 
-type UsageResponse = {
-  usage: Array<Record<string, unknown>>;
-};
+const fetcher = (path: string) => apiFetch<UsageOverview>(path);
 
-const fetcher = (path: string) => apiFetch<UsageResponse>(path);
+function formatLimit(limit: number | null, measurement: string) {
+  if (limit === null) return 'Unlimited';
+  if (measurement === 'tokens') return `${limit.toLocaleString()} tokens`;
+  return limit.toLocaleString();
+}
+
+function formatUsed(used: number, measurement: string) {
+  if (measurement === 'tokens') return `${Math.round(used).toLocaleString()} tokens`;
+  return used.toLocaleString();
+}
+
+function formatRemaining(remaining: number | null, measurement: string) {
+  if (remaining === null) return 'Unlimited';
+  const value = Math.max(Math.floor(remaining), 0);
+  return measurement === 'tokens' ? `${value.toLocaleString()} tokens` : value.toLocaleString();
+}
 
 export default function MonitoringPage() {
   const { tenant } = useTenant();
-  const { data: usage } = useSWR('/dashboard/usage', fetcher);
+  const { data: usage, error } = useSWR('/dashboard/usage', fetcher);
 
   return (
     <>
@@ -19,13 +33,54 @@ export default function MonitoringPage() {
         <title>Monitoring | AI Hairdresser Receptionist</title>
       </Head>
       <main className="monitoring">
-        <section>
+        <section className="header">
           <h1>Monitoring & Overrides</h1>
           <p>Signed in as tenant: {tenant?.name ?? 'Loading…'}</p>
+          {usage && <span className="tier">Current plan: {usage.tier.toUpperCase()}</span>}
         </section>
         <section>
-          <h2>Usage metrics</h2>
-          <pre>{JSON.stringify(usage?.usage ?? [], null, 2)}</pre>
+          <h2>Usage vs tier limits</h2>
+          {error && <p className="error">Failed to load usage overview.</p>}
+          {!usage && !error && <p>Loading usage data…</p>}
+          {usage && (
+            <table>
+              <thead>
+                <tr>
+                  <th>Category</th>
+                  <th>Period</th>
+                  <th>Used</th>
+                  <th>Limit</th>
+                  <th>Remaining</th>
+                </tr>
+              </thead>
+              <tbody>
+                {usage.quotas.map((quota) => (
+                  <tr key={quota.eventType}>
+                    <td>{quota.label}</td>
+                    <td>{quota.period === 'month' ? 'Monthly' : 'Daily'}</td>
+                    <td>{formatUsed(quota.used, quota.measurement)}</td>
+                    <td>{formatLimit(quota.limit, quota.measurement)}</td>
+                    <td>{formatRemaining(quota.remaining, quota.measurement)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </section>
+        <section>
+          <h2>Recent usage metrics</h2>
+          {usage && usage.metrics.length === 0 && <p>No usage metrics recorded yet.</p>}
+          {usage && usage.metrics.length > 0 && (
+            <ul className="metrics">
+              {usage.metrics.map((metric) => (
+                <li key={`${metric.metric}-${metric.occurredAt}`}>
+                  <strong>{metric.metric}</strong>
+                  <span>{metric.value.toLocaleString()}</span>
+                  <small>{new Date(metric.occurredAt).toLocaleString()}</small>
+                </li>
+              ))}
+            </ul>
+          )}
         </section>
         <section>
           <h2>Manual actions</h2>
@@ -39,12 +94,70 @@ export default function MonitoringPage() {
           display: grid;
           gap: 2rem;
         }
-        pre {
+        .header {
+          display: flex;
+          flex-direction: column;
+          gap: 0.5rem;
+        }
+        .tier {
+          display: inline-flex;
+          align-items: center;
+          width: fit-content;
+          padding: 0.35rem 0.75rem;
+          border-radius: 999px;
+          background: #1d4ed8;
+          color: white;
+          font-size: 0.85rem;
+          letter-spacing: 0.04em;
+        }
+        table {
+          width: 100%;
+          border-collapse: collapse;
           background: #0f172a;
           color: #e2e8f0;
-          padding: 1rem;
-          border-radius: 8px;
-          overflow-x: auto;
+          border-radius: 12px;
+          overflow: hidden;
+        }
+        th,
+        td {
+          padding: 0.85rem 1rem;
+          text-align: left;
+        }
+        thead {
+          background: rgba(15, 23, 42, 0.8);
+        }
+        tbody tr:nth-child(even) {
+          background: rgba(15, 23, 42, 0.6);
+        }
+        tbody tr:nth-child(odd) {
+          background: rgba(15, 23, 42, 0.4);
+        }
+        .metrics {
+          list-style: none;
+          padding: 0;
+          margin: 0;
+          display: grid;
+          gap: 0.75rem;
+        }
+        .metrics li {
+          display: flex;
+          justify-content: space-between;
+          align-items: baseline;
+          padding: 0.75rem 1rem;
+          background: #f8fafc;
+          border-radius: 10px;
+        }
+        .metrics strong {
+          color: #0f172a;
+        }
+        .metrics span {
+          font-weight: 600;
+        }
+        .metrics small {
+          color: #475569;
+        }
+        .error {
+          color: #dc2626;
         }
         button {
           margin-right: 1rem;

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -1,3 +1,5 @@
+import type { TenantTier, UsageLimitDefinition } from './types';
+
 export const SYSTEM_ROLES = ['admin', 'staff', 'stylist'] as const;
 export const DEFAULT_TIMEZONE = 'Europe/London';
 export const SUPPORTED_CHANNELS = ['sms', 'whatsapp', 'voice'] as const;
@@ -12,3 +14,58 @@ export const AUDIT_RESOURCE_TYPES = [
   'message',
   'payment'
 ] as const;
+
+type LimitMap = Record<string, UsageLimitDefinition>;
+
+function unlimited(definition: UsageLimitDefinition): UsageLimitDefinition {
+  return { ...definition, limit: null };
+}
+
+const bookingLimit: UsageLimitDefinition = {
+  label: 'Bookings created',
+  period: 'month',
+  limit: 100,
+  measurement: 'events'
+};
+
+const messagingLimit: UsageLimitDefinition = {
+  label: 'Outbound messages',
+  period: 'month',
+  limit: 500,
+  measurement: 'events'
+};
+
+const aiLimit: UsageLimitDefinition = {
+  label: 'AI tokens',
+  period: 'month',
+  limit: 50000,
+  measurement: 'tokens'
+};
+
+const apiLimit: UsageLimitDefinition = {
+  label: 'API calls',
+  period: 'day',
+  limit: 3000,
+  measurement: 'events'
+};
+
+export const TENANT_USAGE_LIMITS: Record<TenantTier, LimitMap> = {
+  starter: {
+    'booking.created': bookingLimit,
+    'message.sent': messagingLimit,
+    'ai.request': aiLimit,
+    'api.call': apiLimit
+  },
+  growth: {
+    'booking.created': { ...bookingLimit, limit: 400 },
+    'message.sent': { ...messagingLimit, limit: 2000 },
+    'ai.request': { ...aiLimit, limit: 200000 },
+    'api.call': { ...apiLimit, limit: 10000 }
+  },
+  scale: {
+    'booking.created': unlimited(bookingLimit),
+    'message.sent': unlimited(messagingLimit),
+    'ai.request': unlimited(aiLimit),
+    'api.call': unlimited(apiLimit)
+  }
+};

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -3,12 +3,15 @@ export type UserId = string;
 export type AppointmentId = string;
 export type BookingId = string;
 
+export type TenantTier = 'starter' | 'growth' | 'scale';
+
 export interface Tenant {
   id: TenantId;
   name: string;
   slug: string;
   contactEmail: string;
   contactPhone?: string;
+  tier: TenantTier;
   createdAt: string;
   updatedAt: string;
   settings: TenantSettings;
@@ -178,7 +181,42 @@ export interface UsageMetric {
   tenantId: TenantId;
   metric: string;
   value: number;
+  metadata?: Record<string, unknown>;
   occurredAt: string;
+}
+
+export interface UsageEvent {
+  id: string;
+  tenantId: TenantId;
+  eventType: string;
+  quantity: number;
+  metadata?: Record<string, unknown>;
+  occurredAt: string;
+}
+
+export type UsageMeasurement = 'events' | 'tokens';
+
+export interface UsageLimitDefinition {
+  label: string;
+  period: 'day' | 'month';
+  limit: number | null;
+  measurement: UsageMeasurement;
+}
+
+export interface UsageQuotaState {
+  eventType: string;
+  label: string;
+  period: 'day' | 'month';
+  measurement: UsageMeasurement;
+  used: number;
+  limit: number | null;
+  remaining: number | null;
+}
+
+export interface UsageOverview {
+  tier: TenantTier;
+  quotas: UsageQuotaState[];
+  metrics: UsageMetric[];
 }
 
 export interface AvailabilityRequest {

--- a/workers/api/src/index.ts
+++ b/workers/api/src/index.ts
@@ -14,6 +14,7 @@ import { withTenant } from './middleware/tenant';
 import { withAuth } from './middleware/auth';
 import { bookingRouter } from './routes/bookings';
 import { assistRouter } from './routes/assist';
+import { checkUsageQuota, recordUsageEvent } from './services/usage-service';
 
 const router = Router();
 
@@ -56,6 +57,22 @@ async function handleRequest(request: Request, env: Env, ctx: ExecutionContext) 
     return authResult;
   }
   scoped = authResult;
+
+  if (scoped.tenantId) {
+    await checkUsageQuota(env, scoped.tenantId, 'api.call', 1);
+    const url = new URL(request.url);
+    ctx.waitUntil(
+      recordUsageEvent(env, scoped.tenantId, 'api.call', {
+        metadata: {
+          path: url.pathname,
+          method: request.method
+        }
+      }).catch((error) => {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error('Failed to record API usage event', { tenantId: scoped.tenantId, message });
+      })
+    );
+  }
 
   return router.handle(scoped, env, ctx);
 }

--- a/workers/api/src/jobs/scheduler.ts
+++ b/workers/api/src/jobs/scheduler.ts
@@ -1,8 +1,10 @@
 import { sendReminderMessages, purgeExpiredData } from '../services/job-service';
+import { aggregateUsageMetrics } from '../services/usage-service';
 
 export async function handleScheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext) {
   const cron = event.cron ?? 'manual';
   console.log('Running scheduled job', cron);
   ctx.waitUntil(sendReminderMessages(env));
   ctx.waitUntil(purgeExpiredData(env));
+  ctx.waitUntil(aggregateUsageMetrics(env));
 }

--- a/workers/api/src/lib/supabase-admin.ts
+++ b/workers/api/src/lib/supabase-admin.ts
@@ -6,6 +6,7 @@ type TenantRow = {
   slug: string;
   contact_email: string;
   contact_phone: string | null;
+  tier?: string;
 };
 
 type UserRow = {

--- a/workers/api/src/routes/dashboard.ts
+++ b/workers/api/src/routes/dashboard.ts
@@ -1,6 +1,7 @@
 import { Router } from 'itty-router';
 import { JsonResponse } from '../lib/response';
-import { getDashboardSummary, getUsageMetrics } from '../services/dashboard-service';
+import { getDashboardSummary } from '../services/dashboard-service';
+import { getUsageOverview } from '../services/usage-service';
 
 const router = Router({ base: '/dashboard' });
 
@@ -10,8 +11,8 @@ router.get('/summary', async (request: TenantScopedRequest, env: Env) => {
 });
 
 router.get('/usage', async (request: TenantScopedRequest, env: Env) => {
-  const usage = await getUsageMetrics(env, request.tenantId!);
-  return JsonResponse.ok({ usage });
+  const usage = await getUsageOverview(env, request.tenantId!);
+  return JsonResponse.ok(usage);
 });
 
 export const dashboardRouter = router;

--- a/workers/api/src/services/assistant-service.ts
+++ b/workers/api/src/services/assistant-service.ts
@@ -64,7 +64,7 @@ export async function generateAssistantSuggestion(env: Env, tenantId: string, pa
     }
   ];
 
-  const suggestion = await callOpenAI(env, {
+  const suggestion = await callOpenAI(env, tenantId, {
     messages,
     temperature: 0.7,
     maxTokens: 260

--- a/workers/api/src/services/auth-service.ts
+++ b/workers/api/src/services/auth-service.ts
@@ -19,7 +19,8 @@ export async function createTenantWithAdmin(input: unknown, env: Env) {
     name: payload.tenantName,
     slug: payload.tenantName.toLowerCase().replace(/[^a-z0-9]+/g, '-'),
     contact_email: payload.email,
-    contact_phone: payload.phone ?? null
+    contact_phone: payload.phone ?? null,
+    tier: 'starter'
   });
 
   const passwordHash = await hashPassword(payload.password);

--- a/workers/api/src/services/dashboard-service.ts
+++ b/workers/api/src/services/dashboard-service.ts
@@ -72,16 +72,3 @@ export async function getDashboardSummary(env: Env, tenantId: string) {
   };
 }
 
-export async function getUsageMetrics(env: Env, tenantId: string) {
-  const client = getClient(env);
-  const { data, error } = await client
-    .from('usage_metrics')
-    .select('*')
-    .eq('tenant_id', tenantId)
-    .order('occurred_at', { ascending: false })
-    .limit(100);
-  if (error) {
-    throw new Error(`Failed to fetch usage metrics: ${error.message}`);
-  }
-  return data ?? [];
-}

--- a/workers/api/src/services/job-service.ts
+++ b/workers/api/src/services/job-service.ts
@@ -1,5 +1,6 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import dayjs from 'dayjs';
+import { recordUsageEvent } from './usage-service';
 
 type TenantRecord = {
   id: string;
@@ -70,6 +71,12 @@ async function sendBookingNotification(env: Env, notification: BookingNotificati
     bookingId: notification.bookingId,
     startTime: notification.scheduledTime,
     channels: notification.channels
+  });
+  await recordUsageEvent(env, notification.tenantId, 'reminder.queued', {
+    metadata: {
+      bookingId: notification.bookingId,
+      channels: notification.channels
+    }
   });
 }
 

--- a/workers/api/src/services/marketing-service.ts
+++ b/workers/api/src/services/marketing-service.ts
@@ -4,7 +4,7 @@ export async function generateAdCopy(env: Env, tenantId: string, payload: any) {
   console.log('Generate ad copy', { tenantId, payload });
   const prompt = `Salon: ${tenantId}. Theme: ${payload.theme ?? 'general'}.
 Craft a social media post promoting ${payload.service ?? 'our services'}.`;
-  const copy = await callOpenAI(env, { prompt });
+  const copy = await callOpenAI(env, tenantId, { prompt });
   return { copy };
 }
 

--- a/workers/api/src/services/usage-service.ts
+++ b/workers/api/src/services/usage-service.ts
@@ -1,0 +1,311 @@
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import dayjs from 'dayjs';
+import {
+  TENANT_USAGE_LIMITS,
+  type TenantTier,
+  type UsageLimitDefinition,
+  type UsageMeasurement,
+  type UsageOverview,
+  type UsageQuotaState
+} from '@ai-hairdresser/shared';
+import { JsonResponse } from '../lib/response';
+
+type UsageEventRow = {
+  quantity?: number | string | null;
+  metadata?: Record<string, unknown> | null;
+  occurred_at?: string | null;
+};
+
+type UsageEventAggregateRow = UsageEventRow & {
+  event_type: string;
+};
+
+const tenantTierCache = new Map<string, TenantTier>();
+
+function getClient(env: Env): SupabaseClient {
+  return createClient(env.SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY);
+}
+
+function normalizeNumber(value: number | string | null | undefined, fallback = 0): number {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : fallback;
+  }
+  if (typeof value === 'string') {
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : fallback;
+  }
+  return fallback;
+}
+
+function getMeasurementValue(row: UsageEventRow, measurement: UsageMeasurement): number {
+  if (measurement === 'tokens') {
+    const meta = row.metadata ?? {};
+    const tokenValue = normalizeNumber((meta as Record<string, unknown>).tokens as number | string | null | undefined, -1);
+    if (tokenValue >= 0) {
+      return tokenValue;
+    }
+  }
+
+  const quantity = normalizeNumber(row.quantity ?? null, 0);
+  return quantity > 0 ? quantity : 1;
+}
+
+async function getTenantTier(client: SupabaseClient, tenantId: string): Promise<TenantTier> {
+  const cached = tenantTierCache.get(tenantId);
+  if (cached) {
+    return cached;
+  }
+
+  const { data, error } = await client.from('tenants').select('tier').eq('id', tenantId).single();
+  if (error) {
+    throw new Error(`Failed to resolve tenant tier: ${error.message}`);
+  }
+
+  const tier = (data?.tier as TenantTier | undefined) ?? 'starter';
+  tenantTierCache.set(tenantId, tier);
+  return tier;
+}
+
+function getLimitMap(tier: TenantTier) {
+  return TENANT_USAGE_LIMITS[tier] ?? {};
+}
+
+async function calculateUsage(
+  client: SupabaseClient,
+  tenantId: string,
+  eventType: string,
+  definition: UsageLimitDefinition,
+  reference: Date
+) {
+  const periodStart = dayjs(reference).startOf(definition.period).toISOString();
+  const { data, error } = await client
+    .from('usage_events')
+    .select('quantity, metadata')
+    .eq('tenant_id', tenantId)
+    .eq('event_type', eventType)
+    .gte('occurred_at', periodStart);
+
+  if (error) {
+    throw new Error(`Failed to calculate usage for ${eventType}: ${error.message}`);
+  }
+
+  const total = (data ?? []).reduce((sum, row) => sum + getMeasurementValue(row as UsageEventRow, definition.measurement), 0);
+
+  return { total, periodStart };
+}
+
+async function resolveLimit(
+  client: SupabaseClient,
+  tenantId: string,
+  eventType: string
+): Promise<{ tier: TenantTier; definition?: UsageLimitDefinition }> {
+  const tier = await getTenantTier(client, tenantId);
+  const limit = getLimitMap(tier)[eventType];
+  return { tier, definition: limit };
+}
+
+export async function checkUsageQuota(
+  env: Env,
+  tenantId: string,
+  eventType: string,
+  amount: number,
+  reference: Date = new Date()
+) {
+  if (!Number.isFinite(amount) || amount <= 0) {
+    return;
+  }
+
+  const client = getClient(env);
+  const { definition } = await resolveLimit(client, tenantId, eventType);
+  if (!definition || definition.limit === null) {
+    return;
+  }
+
+  const { total } = await calculateUsage(client, tenantId, eventType, definition, reference);
+  if (total + amount > definition.limit) {
+    throw JsonResponse.error(
+      `${definition.label} quota exceeded`,
+      429,
+      {
+        limit: definition.limit,
+        used: total,
+        attempted: amount
+      }
+    );
+  }
+}
+
+interface RecordUsageOptions {
+  quantity?: number;
+  metadata?: Record<string, unknown>;
+  occurredAt?: string;
+}
+
+export async function recordUsageEvent(
+  env: Env,
+  tenantId: string,
+  eventType: string,
+  options: RecordUsageOptions = {}
+) {
+  const client = getClient(env);
+  const payload = {
+    tenant_id: tenantId,
+    event_type: eventType,
+    quantity: options.quantity ?? 1,
+    metadata: options.metadata ?? {},
+    occurred_at: options.occurredAt ?? new Date().toISOString()
+  };
+
+  const { error } = await client.from('usage_events').insert(payload);
+  if (error) {
+    throw new Error(`Failed to record usage event: ${error.message}`);
+  }
+}
+
+function buildMetricMetadata(
+  tier: TenantTier,
+  eventType: string,
+  definition: UsageLimitDefinition | undefined,
+  period: 'day' | 'month',
+  periodStart: string
+) {
+  return {
+    tier,
+    eventType,
+    period,
+    periodStart,
+    limit: definition?.limit ?? null,
+    measurement: definition?.measurement ?? 'events'
+  } satisfies Record<string, unknown>;
+}
+
+export async function aggregateUsageMetrics(env: Env) {
+  const client = getClient(env);
+  const tenants = await client.from('tenants').select('id, tier');
+  if (tenants.error) {
+    throw new Error(`Failed to load tenants for usage aggregation: ${tenants.error.message}`);
+  }
+
+  const monthStart = dayjs().startOf('month');
+  const dayStart = dayjs().startOf('day');
+
+  for (const tenant of tenants.data ?? []) {
+    const tenantId = tenant.id as string;
+    const tier = (tenant.tier as TenantTier | undefined) ?? 'starter';
+    tenantTierCache.set(tenantId, tier);
+
+    const { data, error } = await client
+      .from('usage_events')
+      .select('event_type, quantity, metadata, occurred_at')
+      .eq('tenant_id', tenantId)
+      .gte('occurred_at', monthStart.toISOString());
+
+    if (error) {
+      console.error('Usage aggregation failed to load events', { tenantId, message: error.message });
+      continue;
+    }
+
+    const monthlyTotals = new Map<string, number>();
+    const dailyTotals = new Map<string, number>();
+
+    for (const row of data ?? []) {
+      const aggregateRow = row as UsageEventAggregateRow;
+      const definition = getLimitMap(tier)[aggregateRow.event_type];
+      const measurement = definition?.measurement ?? 'events';
+      const value = getMeasurementValue(aggregateRow, measurement);
+      const existing = monthlyTotals.get(aggregateRow.event_type) ?? 0;
+      monthlyTotals.set(aggregateRow.event_type, existing + value);
+
+      if (aggregateRow.occurred_at && dayjs(aggregateRow.occurred_at).isSameOrAfter(dayStart)) {
+        const dayExisting = dailyTotals.get(aggregateRow.event_type) ?? 0;
+        dailyTotals.set(aggregateRow.event_type, dayExisting + value);
+      }
+    }
+
+    const limitMap = getLimitMap(tier);
+
+    const metricsPayload = [
+      {
+        tenant_id: tenantId,
+        metric: 'usage.bookings.month',
+        value: monthlyTotals.get('booking.created') ?? 0,
+        metadata: buildMetricMetadata(tier, 'booking.created', limitMap['booking.created'], 'month', monthStart.toISOString()),
+        occurred_at: monthStart.toISOString()
+      },
+      {
+        tenant_id: tenantId,
+        metric: 'usage.messages.month',
+        value: monthlyTotals.get('message.sent') ?? 0,
+        metadata: buildMetricMetadata(tier, 'message.sent', limitMap['message.sent'], 'month', monthStart.toISOString()),
+        occurred_at: monthStart.toISOString()
+      },
+      {
+        tenant_id: tenantId,
+        metric: 'usage.ai.month.tokens',
+        value: monthlyTotals.get('ai.request') ?? 0,
+        metadata: buildMetricMetadata(tier, 'ai.request', limitMap['ai.request'], 'month', monthStart.toISOString()),
+        occurred_at: monthStart.toISOString()
+      },
+      {
+        tenant_id: tenantId,
+        metric: 'usage.api.day',
+        value: dailyTotals.get('api.call') ?? 0,
+        metadata: buildMetricMetadata(tier, 'api.call', limitMap['api.call'], 'day', dayStart.toISOString()),
+        occurred_at: dayStart.toISOString()
+      }
+    ];
+
+    const { error: upsertError } = await client
+      .from('usage_metrics')
+      .upsert(metricsPayload, { onConflict: 'tenant_id,metric,occurred_at' });
+
+    if (upsertError) {
+      console.error('Failed to upsert usage metrics', { tenantId, message: upsertError.message });
+    }
+  }
+}
+
+export async function getUsageOverview(env: Env, tenantId: string): Promise<UsageOverview> {
+  const client = getClient(env);
+  const tier = await getTenantTier(client, tenantId);
+  const limitMap = getLimitMap(tier);
+  const now = new Date();
+
+  const quotas: UsageQuotaState[] = [];
+  for (const [eventType, definition] of Object.entries(limitMap)) {
+    const { total } = await calculateUsage(client, tenantId, eventType, definition, now);
+    const remaining =
+      definition.limit === null ? null : Math.max(definition.limit - total, 0);
+    quotas.push({
+      eventType,
+      label: definition.label,
+      period: definition.period,
+      measurement: definition.measurement,
+      used: total,
+      limit: definition.limit,
+      remaining
+    });
+  }
+
+  const { data, error } = await client
+    .from('usage_metrics')
+    .select('id, metric, value, metadata, occurred_at')
+    .eq('tenant_id', tenantId)
+    .order('occurred_at', { ascending: false })
+    .limit(100);
+
+  if (error) {
+    throw new Error(`Failed to fetch usage metrics: ${error.message}`);
+  }
+
+  const metrics = (data ?? []).map((row) => ({
+    id: row.id as string,
+    tenantId,
+    metric: row.metric as string,
+    value: normalizeNumber(row.value as number | string | null | undefined, 0),
+    metadata: (row.metadata as Record<string, unknown> | null) ?? undefined,
+    occurredAt: row.occurred_at as string
+  }));
+
+  return { tier, quotas, metrics };
+}


### PR DESCRIPTION
## Summary
- add usage_events schema support with tenant tiers, limits, and aggregation helpers
- record usage for bookings, outbound messages, AI calls, API traffic, and reminders while enforcing per-tier quotas
- surface aggregated metrics and quota status on the admin monitoring page with updated dashboard API

## Testing
- npm test *(fails: external API hostname api.example.com unavailable in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e452660eac8329a7fae7c6d8533538