### PR TITLE
Add onboarding automation and referral workflows

### DIFF
--- a/workers/api/src/jobs/scheduler.ts
+++ b/workers/api/src/jobs/scheduler.ts
@@ -1,8 +1,12 @@
 import { sendReminderMessages, purgeExpiredData } from '../services/job-service';
+import { processNotificationQueue } from '../services/notification-service';
+import { runTenantOnboardingSweep } from '../services/onboarding-service';
 
 export async function handleScheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext) {
   const cron = event.cron ?? 'manual';
   console.log('Running scheduled job', cron);
   ctx.waitUntil(sendReminderMessages(env));
   ctx.waitUntil(purgeExpiredData(env));
+  ctx.waitUntil(processNotificationQueue(env));
+  ctx.waitUntil(runTenantOnboardingSweep(env));
 }

--- a/workers/api/src/routes/dashboard.ts
+++ b/workers/api/src/routes/dashboard.ts
@@ -1,6 +1,6 @@
 import { Router } from 'itty-router';
 import { JsonResponse } from '../lib/response';
-import { getDashboardSummary, getUsageMetrics } from '../services/dashboard-service';
+import { getDashboardSummary, getUsageMetrics, getOnboardingAnalytics } from '../services/dashboard-service';
 
 const router = Router({ base: '/dashboard' });
 
@@ -12,6 +12,11 @@ router.get('/summary', async (request: TenantScopedRequest, env: Env) => {
 router.get('/usage', async (request: TenantScopedRequest, env: Env) => {
   const usage = await getUsageMetrics(env, request.tenantId!);
   return JsonResponse.ok({ usage });
+});
+
+router.get('/analytics', async (_request: TenantScopedRequest, env: Env) => {
+  const analytics = await getOnboardingAnalytics(env);
+  return JsonResponse.ok(analytics);
 });
 
 export const dashboardRouter = router;

--- a/workers/api/src/routes/marketing.ts
+++ b/workers/api/src/routes/marketing.ts
@@ -1,6 +1,12 @@
 import { Router } from 'itty-router';
 import { JsonResponse } from '../lib/response';
-import { generateAdCopy, schedulePost } from '../services/marketing-service';
+import {
+  generateAdCopy,
+  schedulePost,
+  createReferralCode,
+  listReferralCodes,
+  redeemReferralCode
+} from '../services/marketing-service';
 
 const router = Router({ base: '/marketing' });
 
@@ -14,6 +20,23 @@ router.post('/schedule', async (request: TenantScopedRequest, env: Env) => {
   const payload = await request.json();
   const result = await schedulePost(env, request.tenantId!, payload);
   return JsonResponse.ok(result, { status: 202 });
+});
+
+router.post('/referrals', async (request: TenantScopedRequest, env: Env) => {
+  const payload = await request.json();
+  const result = await createReferralCode(env, request.tenantId!, payload);
+  return JsonResponse.ok(result, { status: 201 });
+});
+
+router.get('/referrals', async (request: TenantScopedRequest, env: Env) => {
+  const codes = await listReferralCodes(env, request.tenantId!);
+  return JsonResponse.ok({ codes });
+});
+
+router.post('/referrals/redeem', async (request: TenantScopedRequest, env: Env) => {
+  const payload = await request.json();
+  const result = await redeemReferralCode(env, request.tenantId!, payload);
+  return JsonResponse.ok(result);
 });
 
 export const marketingRouter = router;

--- a/workers/api/src/services/__tests__/onboarding-service.test.ts
+++ b/workers/api/src/services/__tests__/onboarding-service.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateOnboardingSteps } from '../onboarding-service';
+
+describe('evaluateOnboardingSteps', () => {
+  it('marks all steps incomplete when nothing configured', () => {
+    const result = evaluateOnboardingSteps(null, 0, null);
+    expect(result.brandingComplete).toBe(false);
+    expect(result.servicesComplete).toBe(false);
+    expect(result.firstBookingComplete).toBe(false);
+  });
+
+  it('detects branding completion when logo or primary colour present', () => {
+    const result = evaluateOnboardingSteps({ branding: { primaryColor: '#ff00ff' } }, 0, null);
+    expect(result.brandingComplete).toBe(true);
+  });
+
+  it('requires at least one service for servicesComplete', () => {
+    const result = evaluateOnboardingSteps({ branding: {} }, 2, null);
+    expect(result.servicesComplete).toBe(true);
+  });
+
+  it('flags first booking when appointment is present', () => {
+    const result = evaluateOnboardingSteps({}, 0, { start_time: '2024-01-01T10:00:00Z' });
+    expect(result.firstBookingComplete).toBe(true);
+    expect(result.firstBookingAt).toBe('2024-01-01T10:00:00Z');
+  });
+});

--- a/workers/api/src/services/auth-service.ts
+++ b/workers/api/src/services/auth-service.ts
@@ -3,6 +3,7 @@ import { JsonResponse } from '../lib/response';
 import { insertTenant, insertUser, getUserByEmail } from '../lib/supabase-admin';
 import { hashPassword, verifyPassword } from '../lib/passwords';
 import { buildTenantToken } from '../lib/tenant-token';
+import { initializeTenantOnboarding } from './onboarding-service';
 
 const signupInput = z.object({
   tenantName: z.string(),
@@ -32,6 +33,12 @@ export async function createTenantWithAdmin(input: unknown, env: Env) {
     last_name: 'Owner',
     role: 'admin',
     password_hash: passwordHash
+  });
+
+  await initializeTenantOnboarding(env, {
+    id: tenantId,
+    name: tenant.name,
+    contactEmail: tenant.contact_email
   });
 
   return {

--- a/workers/api/src/services/marketing-service.ts
+++ b/workers/api/src/services/marketing-service.ts
@@ -1,4 +1,20 @@
 import { callOpenAI } from '../integrations/openai';
+import { createClient } from '@supabase/supabase-js';
+
+type ReferralCodeRow = {
+  id: string;
+  tenant_id: string;
+  code: string;
+  reward_type: 'percentage' | 'fixed_amount' | 'credit';
+  reward_value: number;
+  max_redemptions: number | null;
+  redemption_count: number | null;
+  expires_at: string | null;
+};
+
+function getClient(env: Env) {
+  return createClient(env.SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY);
+}
 
 export async function generateAdCopy(env: Env, tenantId: string, payload: any) {
   console.log('Generate ad copy', { tenantId, payload });
@@ -11,4 +27,108 @@ Craft a social media post promoting ${payload.service ?? 'our services'}.`;
 export async function schedulePost(_env: Env, tenantId: string, payload: any) {
   console.log('Schedule post placeholder', { tenantId, payload });
   return { status: 'scheduled', runAt: payload.runAt ?? null };
+}
+
+function generateReferralCode(base?: string) {
+  if (base) {
+    return base.trim().toUpperCase().replace(/[^A-Z0-9]/g, '').slice(0, 16);
+  }
+  return Array.from({ length: 8 }, () => 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'[Math.floor(Math.random() * 36)]).join('');
+}
+
+export async function createReferralCode(env: Env, tenantId: string, payload: any) {
+  const client = getClient(env);
+  const code = generateReferralCode(payload?.code);
+  const now = new Date().toISOString();
+  const record = {
+    id: crypto.randomUUID(),
+    tenant_id: tenantId,
+    code,
+    reward_type: payload?.rewardType ?? 'percentage',
+    reward_value: Number(payload?.rewardValue ?? 10),
+    max_redemptions: payload?.maxRedemptions ?? null,
+    redemption_count: 0,
+    expires_at: payload?.expiresAt ?? null,
+    created_at: now,
+    updated_at: now
+  };
+
+  const { data, error } = await client.from('tenant_referral_codes').insert(record).select().single();
+  if (error) {
+    throw new Error(`Failed to create referral code: ${error.message}`);
+  }
+  return data as ReferralCodeRow;
+}
+
+export async function listReferralCodes(env: Env, tenantId: string) {
+  const client = getClient(env);
+  const { data, error } = await client
+    .from('tenant_referral_codes')
+    .select('*')
+    .eq('tenant_id', tenantId)
+    .order('created_at', { ascending: false });
+  if (error) {
+    throw new Error(`Failed to list referral codes: ${error.message}`);
+  }
+  return data ?? [];
+}
+
+export async function redeemReferralCode(env: Env, tenantId: string, payload: any) {
+  if (!payload?.code) {
+    throw new Error('Missing referral code');
+  }
+  const client = getClient(env);
+  const code = generateReferralCode(payload.code);
+  const { data: record, error } = await client
+    .from('tenant_referral_codes')
+    .select('*')
+    .eq('tenant_id', tenantId)
+    .eq('code', code)
+    .maybeSingle();
+  if (error) {
+    throw new Error(`Failed to load referral code: ${error.message}`);
+  }
+  if (!record) {
+    throw new Error('Referral code not found');
+  }
+  if (record.expires_at && new Date(record.expires_at) < new Date()) {
+    throw new Error('Referral code expired');
+  }
+  if (
+    record.max_redemptions !== null &&
+    typeof record.max_redemptions === 'number' &&
+    typeof record.redemption_count === 'number' &&
+    record.redemption_count >= record.max_redemptions
+  ) {
+    throw new Error('Referral code fully redeemed');
+  }
+
+  const updatedCount = (record.redemption_count ?? 0) + 1;
+  const now = new Date().toISOString();
+  const { error: updateError } = await client
+    .from('tenant_referral_codes')
+    .update({ redemption_count: updatedCount, updated_at: now })
+    .eq('id', record.id);
+  if (updateError) {
+    throw new Error(`Failed to update referral code: ${updateError.message}`);
+  }
+
+  await client.from('tenant_referral_redemptions').insert({
+    id: crypto.randomUUID(),
+    tenant_id: tenantId,
+    referral_code_id: record.id,
+    invitee_email: payload?.inviteeEmail ?? null,
+    invitee_tenant_id: payload?.inviteeTenantId ?? null,
+    redeemed_at: now
+  });
+
+  return {
+    code: record.code,
+    reward: {
+      type: record.reward_type,
+      value: record.reward_value
+    },
+    redemptionCount: updatedCount,
+    maxRedemptions: record.max_redemptions
+  };
 }

--- a/workers/api/src/services/notification-service.ts
+++ b/workers/api/src/services/notification-service.ts
@@ -1,0 +1,148 @@
+import { createClient } from '@supabase/supabase-js';
+
+type NotificationChannel = 'email' | 'sms';
+export type NotificationTemplate =
+  | 'welcome_day_0'
+  | 'welcome_day_1'
+  | 'welcome_day_7'
+  | 'nudge_branding'
+  | 'nudge_services'
+  | 'nudge_first_booking';
+
+type NotificationJobRow = {
+  id: string;
+  tenant_id: string;
+  channel: NotificationChannel;
+  template: NotificationTemplate;
+  recipient: string;
+  subject: string | null;
+  payload: Record<string, unknown> | null;
+  send_at: string;
+  status: 'pending' | 'sending' | 'sent' | 'failed' | 'cancelled';
+  attempts: number | null;
+};
+
+type QueueNotificationInput = {
+  template: NotificationTemplate;
+  recipient: string;
+  sendAt: Date | string;
+  channel?: NotificationChannel;
+  subject?: string;
+  body: string;
+};
+
+function getClient(env: Env) {
+  return createClient(env.SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY);
+}
+
+function toIsoDate(input: Date | string) {
+  return input instanceof Date ? input.toISOString() : new Date(input).toISOString();
+}
+
+export async function queueNotification(env: Env, tenantId: string, input: QueueNotificationInput) {
+  const client = getClient(env);
+  const sendAt = toIsoDate(input.sendAt);
+  const payload = { body: input.body };
+  const now = new Date().toISOString();
+
+  const { data, error } = await client
+    .from('notification_jobs')
+    .upsert(
+      {
+        tenant_id: tenantId,
+        channel: input.channel ?? 'email',
+        template: input.template,
+        recipient: input.recipient,
+        subject: input.subject ?? null,
+        payload,
+        send_at: sendAt,
+        status: 'pending',
+        attempts: 0,
+        sent_at: null,
+        last_error: null,
+        updated_at: now
+      },
+      { onConflict: 'tenant_id,template' }
+    )
+    .select()
+    .single();
+
+  if (error) {
+    throw new Error(`Failed to queue notification ${input.template}: ${error.message}`);
+  }
+
+  return data;
+}
+
+async function dispatchEmail(job: NotificationJobRow & { payload: Record<string, unknown> | null }) {
+  const body = typeof job.payload?.body === 'string' ? job.payload?.body : JSON.stringify(job.payload ?? {});
+  console.log('Dispatching onboarding email', {
+    tenantId: job.tenant_id,
+    template: job.template,
+    to: job.recipient,
+    subject: job.subject,
+    preview: body?.slice?.(0, 120)
+  });
+}
+
+async function dispatchNotification(job: NotificationJobRow) {
+  if (job.channel === 'email') {
+    await dispatchEmail(job as NotificationJobRow & { payload: Record<string, unknown> | null });
+    return;
+  }
+
+  console.log('Notification channel not implemented, skipping', {
+    id: job.id,
+    tenantId: job.tenant_id,
+    channel: job.channel
+  });
+}
+
+export async function processNotificationQueue(env: Env, limit = 25) {
+  const client = getClient(env);
+  const nowIso = new Date().toISOString();
+  const { data: due, error } = await client
+    .from('notification_jobs')
+    .select('*')
+    .eq('status', 'pending')
+    .lte('send_at', nowIso)
+    .order('send_at', { ascending: true })
+    .limit(limit);
+
+  if (error) {
+    throw new Error(`Failed to load notification queue: ${error.message}`);
+  }
+
+  for (const job of due ?? []) {
+    const claim = await client
+      .from('notification_jobs')
+      .update({
+        status: 'sending',
+        attempts: (job.attempts ?? 0) + 1,
+        updated_at: new Date().toISOString()
+      })
+      .eq('id', job.id)
+      .eq('status', 'pending')
+      .select('*')
+      .maybeSingle();
+
+    if (claim.error || !claim.data) {
+      continue;
+    }
+
+    try {
+      await dispatchNotification({ ...job, status: 'sending', attempts: (job.attempts ?? 0) + 1 });
+      await client
+        .from('notification_jobs')
+        .update({ status: 'sent', sent_at: new Date().toISOString(), updated_at: new Date().toISOString(), last_error: null })
+        .eq('id', job.id);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      await client
+        .from('notification_jobs')
+        .update({ status: 'failed', last_error: message, updated_at: new Date().toISOString() })
+        .eq('id', job.id);
+      console.error('Notification dispatch failed', { id: job.id, tenantId: job.tenant_id, message });
+    }
+  }
+}

--- a/workers/api/src/services/onboarding-service.ts
+++ b/workers/api/src/services/onboarding-service.ts
@@ -1,0 +1,283 @@
+import dayjs from 'dayjs';
+import { createClient } from '@supabase/supabase-js';
+import { queueNotification, NotificationTemplate } from './notification-service';
+
+type TenantRow = {
+  id: string;
+  name: string;
+  contact_email: string;
+  created_at: string;
+  settings: Record<string, unknown> | null;
+};
+
+type OnboardingProgressRow = {
+  tenant_id: string;
+  branding_completed_at: string | null;
+  services_completed_at: string | null;
+  first_booking_completed_at: string | null;
+  first_booking_conversion_days: number | null;
+  last_nudged_at: string | null;
+  last_step_reminded: string | null;
+};
+
+type OnboardingSteps = {
+  brandingComplete: boolean;
+  servicesComplete: boolean;
+  firstBookingComplete: boolean;
+  firstBookingAt?: string | null;
+};
+
+const NUDGE_INTERVAL_HOURS = 48;
+
+function getClient(env: Env) {
+  return createClient(env.SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY);
+}
+
+function normalizeSettingsBranding(settings: Record<string, unknown> | null | undefined) {
+  if (!settings || typeof settings !== 'object') return null;
+  const branding = (settings as Record<string, unknown>).branding;
+  return typeof branding === 'object' && branding ? (branding as Record<string, unknown>) : null;
+}
+
+export function evaluateOnboardingSteps(
+  settings: Record<string, unknown> | null,
+  servicesCount: number,
+  firstBooking: { start_time: string | null } | null
+): OnboardingSteps {
+  const branding = normalizeSettingsBranding(settings);
+  const brandingComplete = Boolean(branding && (branding.logoUrl || branding.primaryColor));
+  const servicesComplete = servicesCount > 0;
+  const firstBookingAt = firstBooking?.start_time ?? null;
+  const firstBookingComplete = Boolean(firstBookingAt);
+
+  return {
+    brandingComplete,
+    servicesComplete,
+    firstBookingComplete,
+    firstBookingAt
+  };
+}
+
+function buildWelcomeTemplateContent(template: NotificationTemplate, tenantName: string) {
+  switch (template) {
+    case 'welcome_day_0':
+      return {
+        subject: `Welcome to Receptionist, ${tenantName}!`,
+        body: `Hi ${tenantName},\n\nThanks for joining Receptionist. Let's get you set up today — start by customising your branding so clients recognise you straight away.`
+      };
+    case 'welcome_day_1':
+      return {
+        subject: 'Need a hand finishing setup?',
+        body: `Hi ${tenantName},\n\nYou're almost there! Add your core services so the assistant can take bookings for you.`
+      };
+    case 'welcome_day_7':
+      return {
+        subject: 'Ready for your first booking?',
+        body: `Hi ${tenantName},\n\nOne week in! If you haven't already, create a test booking to see the full flow in action. Reply to this email if you need help.`
+      };
+    default:
+      return {
+        subject: 'Quick tip to finish setup',
+        body: `Hi ${tenantName},\n\nJump back into Receptionist to wrap up your onboarding tasks.`
+      };
+  }
+}
+
+function buildNudgeContent(step: keyof Pick<OnboardingSteps, 'brandingComplete' | 'servicesComplete' | 'firstBookingComplete'>, tenantName: string) {
+  switch (step) {
+    case 'brandingComplete':
+      return {
+        template: 'nudge_branding' as NotificationTemplate,
+        subject: 'Add your salon branding',
+        body: `Hi ${tenantName},\n\nUpload your logo and pick your colours so clients get a polished experience when booking.`
+      };
+    case 'servicesComplete':
+      return {
+        template: 'nudge_services' as NotificationTemplate,
+        subject: 'List your key services',
+        body: `Hi ${tenantName},\n\nCreate at least one service so we can start taking bookings for you.`
+      };
+    case 'firstBookingComplete':
+      return {
+        template: 'nudge_first_booking' as NotificationTemplate,
+        subject: 'Time to take your first booking',
+        body: `Hi ${tenantName},\n\nTry creating a booking in the calendar so you can see how Receptionist handles the flow end-to-end.`
+      };
+    default:
+      return {
+        template: 'nudge_branding' as NotificationTemplate,
+        subject: 'Complete your setup',
+        body: `Hi ${tenantName},\n\nJump back into Receptionist to wrap up your onboarding tasks.`
+      };
+  }
+}
+
+export async function initializeTenantOnboarding(env: Env, tenant: { id: string; name: string; contactEmail: string }) {
+  const client = getClient(env);
+  const now = new Date();
+  const welcomeTemplates: Array<{ template: NotificationTemplate; offsetDays: number }> = [
+    { template: 'welcome_day_0', offsetDays: 0 },
+    { template: 'welcome_day_1', offsetDays: 1 },
+    { template: 'welcome_day_7', offsetDays: 7 }
+  ];
+
+  for (const item of welcomeTemplates) {
+    const sendAt = dayjs(now).add(item.offsetDays, 'day').toDate();
+    const content = buildWelcomeTemplateContent(item.template, tenant.name);
+    await queueNotification(env, tenant.id, {
+      template: item.template,
+      recipient: tenant.contactEmail,
+      sendAt,
+      subject: content.subject,
+      body: content.body
+    });
+  }
+
+  await client
+    .from('tenant_onboarding_progress')
+    .upsert(
+      {
+        tenant_id: tenant.id,
+        created_at: now.toISOString(),
+        updated_at: now.toISOString()
+      },
+      { onConflict: 'tenant_id' }
+    );
+}
+
+async function fetchTenantData(env: Env) {
+  const client = getClient(env);
+  const { data, error } = await client.from('tenants').select('id, name, contact_email, created_at, settings');
+  if (error) {
+    throw new Error(`Failed to load tenants for onboarding sweep: ${error.message}`);
+  }
+  return (data ?? []) as TenantRow[];
+}
+
+async function fetchProgressMap(env: Env) {
+  const client = getClient(env);
+  const { data, error } = await client.from('tenant_onboarding_progress').select('*');
+  if (error) {
+    throw new Error(`Failed to load onboarding progress: ${error.message}`);
+  }
+
+  const map = new Map<string, OnboardingProgressRow>();
+  for (const row of data ?? []) {
+    map.set(row.tenant_id, row as OnboardingProgressRow);
+  }
+  return map;
+}
+
+async function fetchServicesCount(env: Env, tenantId: string) {
+  const client = getClient(env);
+  const { count, error } = await client
+    .from('services')
+    .select('*', { count: 'exact', head: true })
+    .eq('tenant_id', tenantId);
+  if (error) {
+    throw new Error(`Failed to count services for tenant ${tenantId}: ${error.message}`);
+  }
+  return count ?? 0;
+}
+
+async function fetchFirstBooking(env: Env, tenantId: string) {
+  const client = getClient(env);
+  const { data, error } = await client
+    .from('appointments')
+    .select('start_time')
+    .eq('tenant_id', tenantId)
+    .in('status', ['confirmed', 'completed'])
+    .order('start_time', { ascending: true })
+    .limit(1);
+  if (error) {
+    throw new Error(`Failed to load first booking for tenant ${tenantId}: ${error.message}`);
+  }
+  return (data?.[0] as { start_time: string } | undefined) ?? null;
+}
+
+async function upsertProgress(env: Env, tenantId: string, updates: Partial<OnboardingProgressRow>) {
+  const client = getClient(env);
+  await client
+    .from('tenant_onboarding_progress')
+    .upsert(
+      {
+        tenant_id: tenantId,
+        ...updates,
+        updated_at: new Date().toISOString()
+      },
+      { onConflict: 'tenant_id' }
+    );
+}
+
+async function insertUsageMetric(env: Env, tenantId: string, value: number) {
+  const client = getClient(env);
+  await client.from('usage_metrics').insert({
+    id: crypto.randomUUID(),
+    tenant_id: tenantId,
+    metric: 'onboarding_conversion',
+    value,
+    occurred_at: new Date().toISOString()
+  });
+}
+
+export async function runTenantOnboardingSweep(env: Env) {
+  const tenants = await fetchTenantData(env);
+  const progressMap = await fetchProgressMap(env);
+  const now = dayjs();
+
+  for (const tenant of tenants) {
+    const progress = progressMap.get(tenant.id) ?? null;
+    const servicesCount = await fetchServicesCount(env, tenant.id);
+    const firstBooking = await fetchFirstBooking(env, tenant.id);
+    const steps = evaluateOnboardingSteps(tenant.settings ?? {}, servicesCount, firstBooking);
+
+    const updates: Partial<OnboardingProgressRow> = {};
+    if (steps.brandingComplete && !progress?.branding_completed_at) {
+      updates.branding_completed_at = now.toISOString();
+    }
+    if (steps.servicesComplete && !progress?.services_completed_at) {
+      updates.services_completed_at = now.toISOString();
+    }
+    if (steps.firstBookingComplete && !progress?.first_booking_completed_at) {
+      const bookingAt = steps.firstBookingAt ? dayjs(steps.firstBookingAt) : now;
+      updates.first_booking_completed_at = bookingAt.toISOString();
+      const conversionDays = bookingAt.diff(dayjs(tenant.created_at), 'day');
+      updates.first_booking_conversion_days = conversionDays >= 0 ? conversionDays : 0;
+    }
+
+    const incompleteSteps: Array<keyof Pick<OnboardingSteps, 'brandingComplete' | 'servicesComplete' | 'firstBookingComplete'>> = [];
+    if (!steps.brandingComplete) incompleteSteps.push('brandingComplete');
+    if (!steps.servicesComplete) incompleteSteps.push('servicesComplete');
+    if (!steps.firstBookingComplete) incompleteSteps.push('firstBookingComplete');
+
+    if (Object.keys(updates).length > 0) {
+      await upsertProgress(env, tenant.id, updates);
+    }
+
+    await insertUsageMetric(env, tenant.id, steps.firstBookingComplete ? 1 : 0);
+
+    if (incompleteSteps.length === 0) {
+      continue;
+    }
+
+    const lastNudgedAt = progress?.last_nudged_at ? dayjs(progress.last_nudged_at) : null;
+    if (lastNudgedAt && now.diff(lastNudgedAt, 'hour') < NUDGE_INTERVAL_HOURS) {
+      continue;
+    }
+
+    const stepKey = incompleteSteps[0];
+    const nudge = buildNudgeContent(stepKey, tenant.name);
+    await queueNotification(env, tenant.id, {
+      template: nudge.template,
+      recipient: tenant.contact_email,
+      sendAt: now.toDate(),
+      subject: nudge.subject,
+      body: nudge.body
+    });
+
+    await upsertProgress(env, tenant.id, {
+      last_nudged_at: now.toISOString(),
+      last_step_reminded: stepKey
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add notification queue and onboarding sweep to send tenant welcome emails and nudges
- extend schema and marketing service with referral code creation, redemption, and tracking
- surface onboarding analytics through the dashboard API and schedule automation jobs

## Testing
- npm test -- --run *(fails: appointments API route still expects 405 for POST/PATCH/DELETE)*
- npx vitest --run src/services/__tests__/onboarding-service.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68e452a0fd688329a93bab41a1e233fe