### PR TITLE
Add Playwright E2E suite with Supabase test harness

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,34 @@
+name: E2E Tests
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  playwright:
+    name: Playwright end-to-end suite
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm install
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+      - name: Run Playwright tests
+        env:
+          CI: 'true'
+        run: npm run test:e2e
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report
+          if-no-files-found: ignore

--- a/apps/web/lib/api-client.ts
+++ b/apps/web/lib/api-client.ts
@@ -1,10 +1,10 @@
-import { createBrowserSupabaseClient } from '@supabase/auth-helpers-nextjs';
+import { getSupabaseBrowserClient } from './supabase-browser-client';
 
 /**
  * Shared fetch wrapper that attaches tenant + auth headers.
  */
 export async function apiFetch<T>(path: string, options: RequestInit & { tenantId?: string } = {}) {
-  const supabase = createBrowserSupabaseClient();
+  const supabase = getSupabaseBrowserClient();
   const session = (await supabase.auth.getSession()).data.session;
   const tenantId = options.tenantId ?? session?.user.user_metadata?.tenant_id;
   if (!tenantId) {

--- a/apps/web/lib/e2e-flags.ts
+++ b/apps/web/lib/e2e-flags.ts
@@ -1,0 +1,7 @@
+export function isBrowserE2ETestEnvironment(): boolean {
+  return typeof process !== 'undefined' && process.env.NEXT_PUBLIC_E2E_TEST === 'true';
+}
+
+export function isServerE2ETestEnvironment(): boolean {
+  return typeof process !== 'undefined' && process.env.E2E_TEST === 'true';
+}

--- a/apps/web/lib/e2e-supabase-server.ts
+++ b/apps/web/lib/e2e-supabase-server.ts
@@ -1,0 +1,228 @@
+import type { GetServerSidePropsContext, NextApiRequest, NextApiResponse } from 'next';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+  E2E_TENANT_EMAIL,
+  E2E_TENANT_ID,
+  E2E_TENANT_NAME,
+  E2E_TENANT_SLUG,
+  createE2EPublicSettingsSeed,
+  createE2EServicesSeed,
+  createE2ETenantRecord,
+  createE2ETenantSettingsSeed
+} from './e2e-test-data';
+
+type ServerContext =
+  | GetServerSidePropsContext
+  | { req: NextApiRequest; res: NextApiResponse };
+
+type SupabaseLikeClient = Pick<SupabaseClient, 'from'> & {
+  auth: {
+    getSession: () => Promise<{ data: { session: unknown }; error: null }>;
+  };
+};
+
+type AdminSupabaseLikeClient = Pick<SupabaseClient, 'from'>;
+
+function parseCookies(rawCookieHeader?: string): Record<string, string> {
+  if (!rawCookieHeader) {
+    return {};
+  }
+
+  return rawCookieHeader.split(';').reduce<Record<string, string>>((acc, chunk) => {
+    const trimmed = chunk.trim();
+    if (!trimmed) {
+      return acc;
+    }
+    const separatorIndex = trimmed.indexOf('=');
+    if (separatorIndex === -1) {
+      acc[decodeURIComponent(trimmed)] = '';
+      return acc;
+    }
+    const key = decodeURIComponent(trimmed.slice(0, separatorIndex));
+    const value = decodeURIComponent(trimmed.slice(separatorIndex + 1));
+    acc[key] = value;
+    return acc;
+  }, {});
+}
+
+function resolveRole(ctx: ServerContext): string {
+  const cookieHeader = ctx.req?.headers?.cookie;
+  const cookies = parseCookies(cookieHeader);
+  return cookies['x-e2e-role'] || 'admin';
+}
+
+function createSession(role: string) {
+  if (role === 'anonymous') {
+    return null;
+  }
+
+  return {
+    access_token: 'e2e-access-token',
+    user: {
+      email: E2E_TENANT_EMAIL,
+      user_metadata: {
+        tenant_id: E2E_TENANT_ID,
+        role,
+        timezone: 'Europe/London'
+      }
+    }
+  };
+}
+
+export function createE2EServerSupabase(ctx: ServerContext): SupabaseLikeClient {
+  const role = resolveRole(ctx);
+  const servicesSeed = createE2EServicesSeed();
+  const tenantSettingsSeed = createE2ETenantSettingsSeed();
+
+  return {
+    auth: {
+      async getSession() {
+        return { data: { session: createSession(role) }, error: null };
+      }
+    },
+    from(table: string) {
+      switch (table) {
+        case 'services':
+          return {
+            select() {
+              return {
+                eq() {
+                  return {
+                    async order() {
+                      return { data: servicesSeed, error: null };
+                    }
+                  };
+                }
+              };
+            }
+          };
+        case 'tenant_settings':
+          return {
+            select() {
+              return {
+                eq() {
+                  return {
+                    async maybeSingle() {
+                      return { data: tenantSettingsSeed, error: null };
+                    }
+                  };
+                }
+              };
+            }
+          };
+        case 'tenants':
+          return {
+            select() {
+              return {
+                eq(_: string, value: string) {
+                  return {
+                    async maybeSingle() {
+                      if (value === E2E_TENANT_SLUG) {
+                        return { data: createE2ETenantRecord(), error: null };
+                      }
+                      return { data: null, error: null };
+                    }
+                  };
+                }
+              };
+            }
+          };
+        default:
+          return {
+            select() {
+              return {
+                eq() {
+                  return {
+                    async order() {
+                      return { data: [], error: null };
+                    },
+                    async maybeSingle() {
+                      return { data: null, error: null };
+                    }
+                  };
+                }
+              };
+            }
+          };
+      }
+    }
+  } as SupabaseLikeClient;
+}
+
+export function createE2EAdminSupabase(): AdminSupabaseLikeClient {
+  const tenantRecord = createE2ETenantRecord();
+  const servicesSeed = createE2EServicesSeed();
+  const publicSettings = createE2EPublicSettingsSeed();
+
+  return {
+    from(table: string) {
+      switch (table) {
+        case 'tenants':
+          return {
+            select() {
+              return {
+                eq(_: string, value: string) {
+                  return {
+                    async maybeSingle() {
+                      if (value === tenantRecord.slug) {
+                        return { data: tenantRecord, error: null };
+                      }
+                      return { data: null, error: null };
+                    }
+                  };
+                }
+              };
+            }
+          };
+        case 'services':
+          return {
+            select() {
+              return {
+                eq(_: string, value: string) {
+                  return {
+                    async order() {
+                      if (value === tenantRecord.id) {
+                        return { data: servicesSeed, error: null };
+                      }
+                      return { data: [], error: null };
+                    }
+                  };
+                }
+              };
+            }
+          };
+        case 'tenant_settings':
+          return {
+            select() {
+              return {
+                eq() {
+                  return {
+                    async maybeSingle() {
+                      return { data: publicSettings, error: null };
+                    }
+                  };
+                }
+              };
+            }
+          };
+        default:
+          return {
+            select() {
+              return {
+                eq() {
+                  return {
+                    async order() {
+                      return { data: [], error: null };
+                    },
+                    async maybeSingle() {
+                      return { data: null, error: null };
+                    }
+                  };
+                }
+              };
+            }
+          };
+      }
+    }
+  } as AdminSupabaseLikeClient;
+}

--- a/apps/web/lib/e2e-test-data.ts
+++ b/apps/web/lib/e2e-test-data.ts
@@ -1,0 +1,57 @@
+export const E2E_TENANT_ID = 'tenant_e2e';
+export const E2E_TENANT_SLUG = 'e2e-salon';
+export const E2E_TENANT_NAME = 'E2E Hair Studio';
+export const E2E_TENANT_EMAIL = 'owner@e2e.test';
+
+export function createE2EServicesSeed() {
+  return [
+    { id: 'svc-cut', tenant_id: E2E_TENANT_ID, name: 'Signature Cut & Finish', duration_minutes: 45, price: 55 },
+    { id: 'svc-colour', tenant_id: E2E_TENANT_ID, name: 'Colour Refresh', duration_minutes: 60, price: 75 }
+  ];
+}
+
+export function createE2ETenantSettingsSeed() {
+  return {
+    timezone: 'Europe/London',
+    business_hours: Array.from({ length: 7 }, (_, weekday) => ({
+      weekday,
+      openTime: weekday === 0 ? '00:00' : '09:00',
+      closeTime: weekday === 0 ? '00:00' : '18:00',
+      closed: weekday === 0
+    })),
+    sms_reminders_enabled: true,
+    email_reminders_enabled: true,
+    reminder_lead_time_minutes: 120,
+    primary_color: '#2563eb',
+    logo_url: null
+  };
+}
+
+export function createE2EPublicSettingsSeed() {
+  return {
+    branding: {
+      primaryColor: '#1f2937',
+      accentColor: '#f97316',
+      backgroundColor: '#f8fafc',
+      textColor: '#111827',
+      logoUrl: null
+    },
+    booking: {
+      startHour: 9,
+      endHour: 17,
+      intervalMinutes: 30,
+      daysToShow: 7,
+      timezone: 'Europe/London'
+    }
+  };
+}
+
+export function createE2ETenantRecord() {
+  return {
+    id: E2E_TENANT_ID,
+    name: E2E_TENANT_NAME,
+    slug: E2E_TENANT_SLUG,
+    contact_email: E2E_TENANT_EMAIL,
+    settings: createE2EPublicSettingsSeed()
+  };
+}

--- a/apps/web/lib/supabase-admin-client.ts
+++ b/apps/web/lib/supabase-admin-client.ts
@@ -1,8 +1,18 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { isServerE2ETestEnvironment } from './e2e-flags';
+import { createE2EAdminSupabase } from './e2e-supabase-server';
 
 let cachedClient: SupabaseClient | null = null;
+let cachedE2EClient: SupabaseClient | null = null;
 
 export function getSupabaseServiceClient(): SupabaseClient {
+  if (isServerE2ETestEnvironment()) {
+    if (!cachedE2EClient) {
+      cachedE2EClient = createE2EAdminSupabase() as unknown as SupabaseClient;
+    }
+    return cachedE2EClient;
+  }
+
   if (cachedClient) {
     return cachedClient;
   }

--- a/apps/web/lib/supabase-browser-client.ts
+++ b/apps/web/lib/supabase-browser-client.ts
@@ -1,0 +1,25 @@
+import { createBrowserSupabaseClient } from '@supabase/auth-helpers-nextjs';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+let cachedClient: SupabaseClient | null = null;
+
+declare global {
+  interface Window {
+    __supabaseClientOverride?: SupabaseClient;
+  }
+}
+
+export function getSupabaseBrowserClient(): SupabaseClient {
+  if (typeof window !== 'undefined' && window.__supabaseClientOverride) {
+    return window.__supabaseClientOverride;
+  }
+
+  if (!cachedClient) {
+    cachedClient = createBrowserSupabaseClient({
+      supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      supabaseKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    });
+  }
+
+  return cachedClient;
+}

--- a/apps/web/lib/supabase-provider.tsx
+++ b/apps/web/lib/supabase-provider.tsx
@@ -1,14 +1,13 @@
-import { createBrowserSupabaseClient } from '@supabase/auth-helpers-nextjs';
 import { SessionContextProvider } from '@supabase/auth-helpers-react';
 import { PropsWithChildren, useState } from 'react';
+import { getSupabaseBrowserClient } from './supabase-browser-client';
 
 export function SupabaseProvider({ children }: PropsWithChildren) {
-  const [supabaseClient] = useState(() =>
-    createBrowserSupabaseClient({
-      supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      supabaseKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-    })
-  );
+  if (typeof window === 'undefined') {
+    return <>{children}</>;
+  }
+
+  const [supabaseClient] = useState(() => getSupabaseBrowserClient());
 
   return (
     <SessionContextProvider supabaseClient={supabaseClient}>{children}</SessionContextProvider>

--- a/apps/web/lib/supabase-server-client.ts
+++ b/apps/web/lib/supabase-server-client.ts
@@ -1,5 +1,7 @@
 import { createPagesServerClient } from '@supabase/auth-helpers-nextjs';
 import type { NextApiRequest, NextApiResponse, GetServerSidePropsContext } from 'next';
+import { isServerE2ETestEnvironment } from './e2e-flags';
+import { createE2EServerSupabase } from './e2e-supabase-server';
 
 type ServerContext =
   | GetServerSidePropsContext
@@ -9,6 +11,10 @@ type ServerContext =
  * Create a Supabase client that is safe to use during SSR/Server handlers.
  */
 export function createSupabaseServerClient(ctx: ServerContext) {
+  if (isServerE2ETestEnvironment()) {
+    return createE2EServerSupabase(ctx) as unknown as ReturnType<typeof createPagesServerClient>;
+  }
+
   return createPagesServerClient(ctx);
 }
 

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -12,6 +12,9 @@
       "@/hooks/*": [
         "hooks/*"
       ],
+      "@/styles/*": [
+        "styles/*"
+      ],
       "@/types": [
         "../../packages/shared/src/types"
       ],

--- a/e2e/tenant-onboarding.spec.ts
+++ b/e2e/tenant-onboarding.spec.ts
@@ -1,0 +1,337 @@
+import { expect, test } from '@playwright/test';
+import type { Page } from '@playwright/test';
+import {
+  E2E_TENANT_EMAIL,
+  E2E_TENANT_ID,
+  E2E_TENANT_NAME,
+  E2E_TENANT_SLUG,
+  createE2EServicesSeed
+} from '../apps/web/lib/e2e-test-data';
+
+const TENANT_CONTACT_PHONE = '+447000000000';
+type ServiceSeed = ReturnType<typeof createE2EServicesSeed>[number];
+
+async function stubExternalVendors(page: Page) {
+  await page.route('https://api.stripe.com/**', (route) =>
+    route.fulfill({ status: 200, body: JSON.stringify({ id: 'pi_test_123', status: 'succeeded' }) })
+  );
+  await page.route('https://api.twilio.com/**', (route) =>
+    route.fulfill({ status: 200, body: JSON.stringify({ sid: 'tw_test_123', status: 'queued' }) })
+  );
+  await page.route('https://api.openai.com/**', (route) =>
+    route.fulfill({ status: 200, body: JSON.stringify({ id: 'chatcmpl_test', choices: [] }) })
+  );
+}
+
+test.describe('Tenant onboarding and booking journeys', () => {
+  test.beforeEach(async ({ page, context }) => {
+    await context.addCookies([
+      {
+        name: 'x-e2e-role',
+        value: 'admin',
+        url: 'http://127.0.0.1:3000',
+        path: '/',
+        httpOnly: false
+      }
+    ]);
+
+    await stubExternalVendors(page);
+
+    await page.addInitScript(
+      ({ tenantId, servicesSeed, tenantEmail }: { tenantId: string; servicesSeed: ServiceSeed[]; tenantEmail: string }) => {
+        const servicesState = servicesSeed.map((service: ServiceSeed) => ({
+          ...service
+        }));
+
+      const tenantSettings = {
+        timezone: 'Europe/London',
+        business_hours: Array.from({ length: 7 }, (_, weekday) => ({
+          weekday,
+          openTime: weekday === 0 ? '00:00' : '09:00',
+          closeTime: weekday === 0 ? '00:00' : '18:00',
+          closed: weekday === 0
+        })),
+        sms_reminders_enabled: true,
+        email_reminders_enabled: true,
+        reminder_lead_time_minutes: 120,
+        primary_color: '#2563eb',
+        logo_url: null
+      };
+
+      const supabaseMock = {
+        auth: {
+          async getSession() {
+            return {
+              data: {
+                session: {
+                  access_token: 'browser-e2e-token',
+                  user: {
+                    email: tenantEmail,
+                    user_metadata: {
+                      tenant_id: tenantId,
+                      role: 'admin',
+                      timezone: 'Europe/London'
+                    }
+                  }
+                }
+              },
+              error: null
+            };
+          }
+        },
+        from(table: string) {
+          if (table === 'services') {
+            return {
+              async upsert(payload: any[]) {
+                payload.forEach((entry) => {
+                  const targetId = entry.id ?? `svc-${Math.random().toString(36).slice(2, 8)}`;
+                  const existingIndex = servicesState.findIndex((service) => service.id === targetId);
+                  const nextRecord = {
+                    id: targetId,
+                    tenant_id: tenantId,
+                    name: entry.name,
+                    duration_minutes: entry.duration_minutes ?? entry.durationMinutes,
+                    price: entry.price
+                  };
+                  if (existingIndex >= 0) {
+                    servicesState[existingIndex] = nextRecord;
+                  } else {
+                    servicesState.push(nextRecord);
+                  }
+                });
+                return { data: servicesState, error: null };
+              },
+              delete() {
+                return {
+                  async in(_: string, ids: string[]) {
+                    ids.forEach((id) => {
+                      const index = servicesState.findIndex((service) => service.id === id);
+                      if (index >= 0) {
+                        servicesState.splice(index, 1);
+                      }
+                    });
+                    return { data: null, error: null };
+                  }
+                };
+              },
+              select() {
+                return {
+                  eq() {
+                    return {
+                      async order() {
+                        return { data: servicesState, error: null };
+                      }
+                    };
+                  }
+                };
+              }
+            };
+          }
+
+          if (table === 'tenant_settings') {
+            return {
+              async upsert(entry: any) {
+                Object.assign(tenantSettings, {
+                  timezone: entry.timezone,
+                  business_hours: entry.business_hours,
+                  sms_reminders_enabled: entry.sms_reminders_enabled,
+                  email_reminders_enabled: entry.email_reminders_enabled,
+                  reminder_lead_time_minutes: entry.reminder_lead_time_minutes,
+                  primary_color: entry.primary_color,
+                  logo_url: entry.logo_url ?? null
+                });
+                return { data: tenantSettings, error: null };
+              }
+            };
+          }
+
+          return {
+            select() {
+              return {
+                eq() {
+                  return {
+                    async order() {
+                      return { data: [], error: null };
+                    },
+                    async maybeSingle() {
+                      return { data: null, error: null };
+                    }
+                  };
+                }
+              };
+            }
+          };
+        },
+        storage: {
+          from() {
+            return {
+              async upload() {
+                return { data: { path: 'logos/mock.png' }, error: null };
+              },
+              getPublicUrl(path: string) {
+                return { data: { publicUrl: `https://cdn.test/${path}` } };
+              }
+            };
+          }
+        }
+      };
+
+        (window as unknown as { __supabaseClientOverride: typeof supabaseMock }).__supabaseClientOverride = supabaseMock;
+        (window as unknown as { __e2eServicesState: typeof servicesState }).__e2eServicesState = servicesState;
+      }, { tenantId: E2E_TENANT_ID, servicesSeed: createE2EServicesSeed(), tenantEmail: E2E_TENANT_EMAIL });
+  });
+
+  test('completes signup, configuration, booking confirmation and reminder flow', async ({ page }) => {
+    const servicesSeed = createE2EServicesSeed();
+
+    await page.route('**/api/auth/signup', async (route, request) => {
+      const payload = await request.postDataJSON();
+      expect(payload.tenantName).toBe('E2E Hair Studio');
+      expect(payload.email).toBe(E2E_TENANT_EMAIL);
+      route.fulfill({ status: 200, body: JSON.stringify({ tenantId: E2E_TENANT_ID }) });
+    });
+
+    await page.route('**/api/dashboard/summary', (route) =>
+      route.fulfill({
+        status: 200,
+        body: JSON.stringify({
+          upcomingAppointments: 4,
+          pendingConfirmations: 1,
+          pendingMessages: 2,
+          revenueLast30d: 1480,
+          pendingDeposits: 1,
+          collectedDeposits: 6
+        })
+      })
+    );
+
+    await page.route('**/api/tenants/me', (route) =>
+      route.fulfill({
+        status: 200,
+        body: JSON.stringify({
+          id: E2E_TENANT_ID,
+          name: E2E_TENANT_NAME,
+          slug: E2E_TENANT_SLUG,
+          contactEmail: E2E_TENANT_EMAIL,
+          contactPhone: TENANT_CONTACT_PHONE,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+          settings: {
+            defaultDepositType: 'fixed',
+            defaultDepositValue: 2000,
+            depositsEnabled: true,
+            timezone: 'Europe/London',
+            locale: 'en-GB',
+            cancellationPolicy: '24h notice required.'
+          }
+        })
+      })
+    );
+
+    await page.route('**/api/bookings', (route) =>
+      route.fulfill({
+        status: 200,
+        body: JSON.stringify({ id: 'booking_test', status: 'pending', remindersScheduled: true })
+      })
+    );
+
+    await page.goto('/auth/signup');
+    await page.getByLabel('Salon name').fill(E2E_TENANT_NAME);
+    await page.getByLabel('Admin email').fill(E2E_TENANT_EMAIL);
+    await page.getByLabel('Admin password').fill('A-secure-passw0rd');
+    await page.getByLabel('Contact phone').fill(TENANT_CONTACT_PHONE);
+    await Promise.all([
+      page.waitForURL('**/dashboard'),
+      page.getByRole('button', { name: 'Sign up' }).click()
+    ]);
+
+    await expect(page.getByRole('heading', { name: 'Tenant overview' })).toBeVisible();
+    await expect(page.getByText('Upcoming appointments')).toBeVisible();
+    await expect(page.getByText('£1480.00')).toBeVisible();
+
+    await page.goto('/admin/settings');
+    await expect(page.getByRole('heading', { name: 'Tenant settings' })).toBeVisible();
+    await page.getByRole('button', { name: 'Add service' }).click();
+    const newServiceName = 'Balayage Glow';
+    const lastCard = page.locator('.service-card').last();
+    await lastCard.getByLabel('Name').fill(newServiceName);
+    await lastCard.getByLabel('Duration (minutes)').fill('120');
+    await lastCard.getByLabel('Price (£)').fill('110');
+    await page.getByRole('spinbutton', { name: 'Reminder lead time (minutes)' }).fill('90');
+    await page.getByRole('button', { name: 'Save settings' }).click();
+    await expect(page.getByText('Settings saved successfully.')).toBeVisible();
+
+    const serviceCount = await page.evaluate(() => {
+      return (window as unknown as { __e2eServicesState: ReturnType<typeof createE2EServicesSeed> }).__e2eServicesState.length;
+    });
+    expect(serviceCount).toBeGreaterThan(servicesSeed.length);
+
+    await page.goto(`/book/${E2E_TENANT_SLUG}`);
+    await expect(page.getByRole('heading', { name: E2E_TENANT_NAME })).toBeVisible();
+    await page.locator('select[name="serviceId"]').selectOption(servicesSeed[0].id);
+    const firstSlot = page.locator('.slot-grid .slot').first();
+    await firstSlot.waitFor();
+    await firstSlot.click();
+    await page.getByLabel('Full name').fill('Alex Client');
+    await page.getByLabel('Email').fill('alex.client@example.com');
+    await page.getByLabel('Phone').fill('+447123123123');
+    await page.getByLabel('Notes (optional)').fill('Please add a hydrating treatment.');
+    await page.getByRole('button', { name: 'Request appointment' }).click();
+
+    await expect(page.getByRole('heading', { name: 'Booking request received' })).toBeVisible();
+    await expect(
+      page.getByText('A member of the team will confirm the appointment shortly.')
+    ).toBeVisible();
+  });
+
+  test('surface payment failure during booking checkout', async ({ page }) => {
+    await page.route('**/api/bookings', (route) =>
+      route.fulfill({
+        status: 402,
+        body: JSON.stringify({ error: 'Payment failed: card declined.' })
+      })
+    );
+
+    await page.goto(`/book/${E2E_TENANT_SLUG}`);
+    await page.getByLabel('Full name').fill('Jordan Client');
+    await page.getByLabel('Email').fill('jordan.client@example.com');
+    const slot = page.locator('.slot-grid .slot').first();
+    await slot.waitFor();
+    await slot.click();
+    await page.getByRole('button', { name: 'Request appointment' }).click();
+
+    await expect(page.getByText('Payment failed: card declined.')).toBeVisible();
+  });
+
+  test('communicates over-quota errors when booking volume exceeded', async ({ page }) => {
+    await page.route('**/api/bookings', (route) =>
+      route.fulfill({ status: 429, body: JSON.stringify({ error: 'Tenant quota exceeded.' }) })
+    );
+
+    await page.goto(`/book/${E2E_TENANT_SLUG}`);
+    await page.getByLabel('Full name').fill('Taylor Client');
+    await page.getByLabel('Email').fill('taylor.client@example.com');
+    const quotaSlot = page.locator('.slot-grid .slot').first();
+    await quotaSlot.waitFor();
+    await quotaSlot.click();
+    await page.getByRole('button', { name: 'Request appointment' }).click();
+
+    await expect(page.getByText('Tenant quota exceeded.')).toBeVisible();
+  });
+
+  test('blocks non-admin access to privileged settings areas', async ({ page, context }) => {
+    await context.addCookies([
+      {
+        name: 'x-e2e-role',
+        value: 'stylist',
+        url: 'http://127.0.0.1:3000',
+        path: '/' ,
+        httpOnly: false
+      }
+    ]);
+
+    await page.goto('/admin/settings');
+    await page.waitForTimeout(500);
+    await expect(page).toHaveURL(/\/dashboard$/);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -14,9 +14,11 @@
     "lint:web": "npm run lint --workspace apps/web",
     "dev:worker": "npm run dev --workspace workers/api",
     "deploy:worker": "npm run deploy --workspace workers/api",
-    "test": "vitest"
+    "test": "vitest",
+    "test:e2e": "playwright test"
   },
   "devDependencies": {
+    "@playwright/test": "^1.41.2",
     "@testing-library/jest-dom": "^6.1.5",
     "@testing-library/react": "^14.1.2",
     "@testing-library/user-event": "^14.5.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,45 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const isCI = !!process.env.CI;
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: isCI,
+  retries: isCI ? 1 : 0,
+  workers: isCI ? 2 : undefined,
+  reporter: isCI
+    ? [
+        ['github'],
+        ['html', { outputFolder: 'playwright-report', open: 'never' }]
+      ]
+    : [['list']],
+  use: {
+    baseURL: 'http://127.0.0.1:3000',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure'
+  },
+  webServer: {
+    command: 'npm run dev --workspace apps/web -- --hostname 127.0.0.1 --port 3000',
+    url: 'http://127.0.0.1:3000',
+    reuseExistingServer: !isCI,
+    timeout: 120_000,
+    env: {
+      NEXT_PUBLIC_SUPABASE_URL: 'https://supabase.test',
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: 'supabase-anon-key',
+      SUPABASE_URL: 'https://supabase.test',
+      SUPABASE_SERVICE_ROLE_KEY: 'service-role-test-key',
+      NEXT_PUBLIC_API_BASE_URL: 'https://api.test',
+      E2E_TEST: 'true',
+      NEXT_PUBLIC_E2E_TEST: 'true',
+      NODE_OPTIONS: '--preserve-symlinks'
+    }
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] }
+    }
+  ]
+});


### PR DESCRIPTION
## Summary
- add Playwright-based end-to-end tests that exercise signup, settings, public booking, and negative paths with mocked external vendors
- introduce test-only Supabase client overrides and server stubs to make browser and SSR flows deterministic in CI
- configure GitHub Actions workflow to run the new E2E suite prior to deployments and expose convenient npm scripts

## Testing
- npx playwright test *(fails: Next.js dev server reports invalid hook call due to duplicate React in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e452b603e08329b0e6e079e06c1e37