### PR TITLE
Add Codex task automation scaffolding

### DIFF
--- a/codex-tasks/01-ui-polish.md
+++ b/codex-tasks/01-ui-polish.md
@@ -1,0 +1,29 @@
+---
+id: "01"
+title: "Responsive UI & UX Polish"
+status: "pending"
+priority: "high"
+category: "polish"
+---
+
+You are designing a comprehensive responsive polishing pass for the multi-tenant AI salon receptionist web app built with Next.js 14, React Server Components, Tailwind CSS, and Supabase auth. The product serves salon owners who manage multiple locations and receptionists that triage bookings. The goal is to deliver a production-ready user experience across desktop, tablet, and mobile breakpoints.
+
+**Context**
+- The main navigation currently lives in `apps/web/app/(dashboard)` and provides entry points for Inbox, Calendar, Automations, and Billing.
+- Component primitives live in `packages/shared/ui` and should remain the single source of truth for typography, colors, spacing, and interactive states.
+- Dark mode is already available via the design tokens but is inconsistently applied across pages.
+
+**Objectives**
+1. Audit every page and shared layout in the dashboard bundle to ensure fluid responsive behavior (including 2-column -> 1-column transitions, overflow handling, and touch-safe hit targets).
+2. Harmonize typography scale, color usage, and component spacing against the design tokens. Update Tailwind config or shared components if new tokens are required.
+3. Implement accessible focus states, form labels, and ARIA attributes for all interactive elements. Verify using Lighthouse or axe-core that no WCAG AA blocker remains.
+4. Extend the shared `ThemeProvider` to support smooth dark/light mode transitions and ensure there are no visual regressions when toggling themes.
+5. Document the final responsive layout guidelines in `apps/web/docs/ui-guidelines.md` (create the file if missing) with screenshots or Figma links supplied via config.
+
+**Deliverables**
+- Updated React components, Tailwind styles, and shared UI primitives delivering pixel-perfect responsive layouts.
+- An updated design token set (if needed) with migration notes.
+- Accessibility fixes validated by automated tooling (attach report summary in PR).
+- A written UI guideline document summarizing breakpoints, spacing, and theme recommendations.
+
+Assume you can run `npm run lint:web` and `npm run test:e2e` to confirm regressions. Collaborate closely with design but keep implementation self-contained.

--- a/codex-tasks/02-pwa-support.md
+++ b/codex-tasks/02-pwa-support.md
@@ -1,0 +1,28 @@
+---
+id: "02"
+title: "PWA Support"
+status: "pending"
+priority: "high"
+category: "infrastructure"
+---
+
+You are responsible for delivering robust Progressive Web App support for the AI receptionist dashboard so salons can install it on tablets at the front desk. The app is built with Next.js 14 (App Router) deployed on Vercel, uses Supabase for authentication, and relies on a Worker backend for realtime notifications.
+
+**Context**
+- The web workspace currently lacks a service worker and manifest configuration.
+- Push notifications will later be handled via the existing Worker API, but this task should unblock installation and offline basics first.
+- We support multi-tenant branding so PWA metadata must read tenant-specific colors and icons from Supabase storage.
+
+**Objectives**
+1. Create a Web App Manifest in `apps/web/public/manifest.webmanifest` with dynamic values generated at request time via Next.js metadata API. Include icons, theme colors, shortcuts, and related applications.
+2. Implement a TypeScript service worker using Workbox (or a custom caching strategy) compiled to `public/sw.js`. Cache shell assets, fonts, and API responses required for the offline appointment list.
+3. Wire up automatic service worker registration in the dashboard layout with retry/backoff logic, including `beforeinstallprompt` UX to encourage installation.
+4. Provide a tenant-aware theming mechanism so manifest icons/colors update per tenant slug (pull from Supabase storage and fall back gracefully).
+5. Document testing steps covering Lighthouse PWA audits, offline navigation, and install flows on Chrome + Safari iOS.
+
+**Deliverables**
+- Manifest, service worker, and registration code committed with clear comments.
+- Integration tests or manual QA notes proving offline appointment access works.
+- Updated documentation outlining how to add new tenant icons and what files must be uploaded.
+
+Ensure the solution is compatible with Next.js static asset pipeline and does not block SSR. Provide guidance on cache invalidation during deploys.

--- a/codex-tasks/03-custom-domains.md
+++ b/codex-tasks/03-custom-domains.md
@@ -1,0 +1,29 @@
+---
+id: "03"
+title: "Custom Domains for Tenants"
+status: "pending"
+priority: "high"
+category: "growth"
+---
+
+You are implementing custom domain support so each salon tenant can map their own receptionist portal to a branded hostname (e.g., `reception.salonname.com`). The stack uses Next.js on Vercel for the frontend, Cloudflare Workers for APIs, and Supabase for tenant metadata.
+
+**Context**
+- Tenant records already include `vanity_hostname` and SSL certificate provisioning status fields, but we do not yet orchestrate domain verification or routing.
+- Vercel supports wildcard domain routing via the Projects API, and Cloudflare handles DNS and certificate issuance.
+- The receptionist portal must respect tenant-specific theme and legal footer content when served under a custom domain.
+
+**Objectives**
+1. Build an admin workflow in `apps/web/app/(dashboard)/settings/domains` allowing tenants to request, verify, and activate a custom domain. Include validation for CNAME/A record requirements and status polling.
+2. Implement backend orchestration in `workers/api/src/routes/domains.ts` that calls Cloudflare and Vercel APIs to provision DNS records, request certificates, and attach domains to the Vercel project.
+3. Securely store API credentials in Supabase secrets or environment variables, and design retry-safe jobs for certificate issuance using our existing queue system.
+4. Update Supabase tenant metadata when domain status changes (pending → verifying → active) and emit audit logs for compliance.
+5. Add documentation and support tooling (`scripts/domains.ts`) to re-sync domains in case of drift, including CLI usage examples.
+
+**Deliverables**
+- A tenant-facing UI/UX for managing custom domains with real-time validation feedback.
+- Worker routes and background jobs orchestrating DNS + SSL provisioning with error handling and observability metrics.
+- Updated Supabase schema migrations, types, and seeds reflecting domain lifecycle fields.
+- Playbook docs describing how support can troubleshoot failed verifications and roll back domains safely.
+
+Ensure the feature is idempotent, resilient to API rate limits, and fully auditable. Include automated tests where feasible.

--- a/codex-tasks/04-gdpr-compliance.md
+++ b/codex-tasks/04-gdpr-compliance.md
@@ -1,0 +1,29 @@
+---
+id: "04"
+title: "GDPR & Legal Compliance Tools"
+status: "pending"
+priority: "high"
+category: "compliance"
+---
+
+You are adding comprehensive GDPR tooling so European salon tenants can confidently use the AI receptionist while meeting regulatory requirements. This includes data export, right-to-be-forgotten workflows, consent capture, and audit trails.
+
+**Context**
+- Customer data resides in Supabase Postgres with row-level security per tenant and is synced to the AI assistant via Supabase Functions.
+- Current legal settings only allow toggling marketing opt-in at signup; there is no centralized consent ledger.
+- We already use Clerk for auth in the dashboard but rely on Supabase for tenant data storage.
+
+**Objectives**
+1. Design and implement a `compliance` schema in Supabase to store consent receipts, privacy policy versions, and audit events. Create migrations, types, and triggers to keep data consistent.
+2. Build an in-dashboard GDPR console under `apps/web/app/(dashboard)/settings/compliance` where admins can initiate data export/erasure requests, view consent history, and download audit logs (CSV + JSON).
+3. Create background jobs in the Worker API to process export and deletion tasks, including anonymizing personal data across all relevant tables (appointments, messages, AI transcripts). Provide dry-run mode and notifications.
+4. Implement consent capture APIs that integrate with the receptionist chat widget to store timestamped consents linked to session IDs. Update the chat widget to display localized consent banners when required.
+5. Document legal workflows with diagrams and runbooks, including how to respond to data subject access requests within 30 days and how to configure policy versions per tenant.
+
+**Deliverables**
+- Supabase migrations and types for compliance schema plus automated tests verifying data integrity.
+- Dashboard UI with secure download links and RBAC gating to compliance admins only.
+- Worker jobs with retry logic, thorough logging, and notifications to admins when tasks complete.
+- Comprehensive documentation for legal, support, and engineering stakeholders.
+
+Ensure all workflows are fully auditable, protect personally identifiable information, and meet GDPR Article 30 record-keeping requirements.

--- a/codex-tasks/05-beta-program.md
+++ b/codex-tasks/05-beta-program.md
@@ -1,0 +1,29 @@
+---
+id: "05"
+title: "Beta Program Workflow"
+status: "pending"
+priority: "medium"
+category: "growth"
+---
+
+You are establishing an end-to-end beta program workflow so product managers can invite select salons to preview experimental AI receptionist features. The system needs to handle cohort enrollment, feature flagging, feedback collection, and automated reporting.
+
+**Context**
+- Feature flags currently live in LaunchDarkly with a simple on/off per tenant toggle.
+- Feedback is collected manually via Notion and Slack, lacking structure.
+- Supabase stores tenant tiers and plan data that can be used to filter eligible beta participants.
+
+**Objectives**
+1. Extend the feature flag integration to support named beta cohorts with automated enrollment rules. Add support for staged rollouts and dynamic targeting expressions.
+2. Build a beta management UI at `apps/web/app/(dashboard)/settings/beta-program` where admins can invite tenants, monitor engagement, and view aggregated sentiment scores.
+3. Create backend APIs and Supabase tables to store beta invitations, acceptance status, and feedback notes tagged by feature flag key.
+4. Integrate an in-app feedback widget that surfaces beta-specific surveys in the Inbox and collects qualitative feedback stored via Supabase Functions.
+5. Generate weekly beta health reports delivered via email and Slack summarizing enrollment, usage metrics (from PostHog), and outstanding issues.
+
+**Deliverables**
+- LaunchDarkly integration updates, Supabase schema additions, and worker jobs to orchestrate invites + reminders.
+- Dashboard components, charts, and feedback UI with proper RBAC (product + support roles only).
+- Automated reports implemented via existing notifications service with templates stored in the repo.
+- Documentation describing how to start/stop a beta, invite tenants, and interpret analytics dashboards.
+
+Ensure the workflow is extensible to multiple simultaneous betas and complies with tenant data isolation rules.

--- a/codex-tasks/06-in-app-support.md
+++ b/codex-tasks/06-in-app-support.md
@@ -1,0 +1,29 @@
+---
+id: "06"
+title: "In-App Support / Live Chat"
+status: "pending"
+priority: "medium"
+category: "growth"
+---
+
+You are creating a native in-app support experience so salon owners can chat with our success team without leaving the receptionist dashboard. The solution should blend AI triage with human takeover and integrate with our existing Intercom + Slack workflows.
+
+**Context**
+- We currently link out to an external help center; there is no embedded widget.
+- The AI receptionist already has a conversation pipeline that can be reused for classification and response suggestions.
+- Support agents operate out of Slack using a custom bot that mirrors conversations from Supabase.
+
+**Objectives**
+1. Build a persistent support widget accessible from any dashboard page that opens a side-panel chat. Persist conversation state per user and device.
+2. Implement AI triage that suggests responses using our GPT-4o function calling setup. Responses should auto-tag by topic and escalate to human agents if confidence is below a threshold.
+3. Integrate with Slack via the existing bot to notify agents of new escalations, including conversation context and user metadata. Allow two-way syncing of messages.
+4. Add support analytics (response times, CSAT) to the admin dashboard, backed by new Supabase tables and scheduled jobs to compute metrics.
+5. Document SLAs, runbooks for escalation, and how to test the AI fallback flows locally.
+
+**Deliverables**
+- React components for the support widget, conversation store, and notifications.
+- Worker endpoints for AI triage, Slack sync, and conversation persistence with rate limiting and error handling.
+- Analytics dashboards and background jobs generating KPIs.
+- Documentation for support and engineering teams, including feature flags and rollout strategy.
+
+Ensure the experience is real-time, accessible, and respects tenant isolation rules. Provide unit tests where critical (AI classification, Slack sync handlers).

--- a/codex-tasks/07-developer-cli.md
+++ b/codex-tasks/07-developer-cli.md
@@ -1,0 +1,29 @@
+---
+id: "07"
+title: "Developer CLI & Tenant Tools"
+status: "pending"
+priority: "medium"
+category: "infrastructure"
+---
+
+You are delivering a developer-focused CLI and tooling suite to streamline tenant onboarding, local development, and operational tasks. The CLI should be built with Node.js + TypeScript, distributed via npm within the monorepo, and integrate with Supabase + Cloudflare APIs.
+
+**Context**
+- Engineers currently run ad-hoc scripts for seeding tenants, managing webhooks, and invoking background jobs.
+- There is no single source of truth for environment configuration across workspaces.
+- We use pnpm workspaces in CI, but developers often rely on `npm` locally.
+
+**Objectives**
+1. Create a `packages/cli` workspace that exports a `receptionist` CLI with commands for tenant bootstrap, data seeding, log tailing, and queue inspection.
+2. Implement shared config loading (dotenv + Supabase typed env) with validation and helpful error messages.
+3. Add commands to invoke Cloudflare Worker routes, Supabase edge functions, and AI pipeline dry runs. Provide human-friendly output and JSON modes for automation.
+4. Integrate authentication using personal access tokens stored in 1Password. Provide docs on how to create and rotate these tokens.
+5. Update developer onboarding docs to reference the new CLI, including examples, shell completions, and troubleshooting tips.
+
+**Deliverables**
+- A fully documented CLI package with unit tests and typed command definitions (e.g., using oclif or commander).
+- Shared config utilities reused by other scripts to eliminate duplication.
+- Updated READMEs and onboarding guides pointing to the CLI as the canonical toolset.
+- CI step ensuring the CLI builds successfully and lint/tests pass.
+
+Design the CLI to be extensible, safe (no destructive operations without confirmations), and friendly for junior engineers.

--- a/codex-tasks/08-cicd-automation.md
+++ b/codex-tasks/08-cicd-automation.md
@@ -1,0 +1,29 @@
+---
+id: "08"
+title: "CI/CD & Deployment Automation"
+status: "pending"
+priority: "medium"
+category: "infrastructure"
+---
+
+You are responsible for maturing the CI/CD pipeline so every commit can be safely deployed to production with minimal manual steps. The stack uses GitHub Actions, Vercel for the Next.js app, Cloudflare Workers for APIs, and Supabase migrations.
+
+**Context**
+- Current pipelines run lint/test but deployments are still triggered manually.
+- Database migrations are applied manually via Supabase CLI.
+- Rollbacks require multiple commands and lack observability.
+
+**Objectives**
+1. Consolidate CI workflows into `.github/workflows/release.yml` that runs unit tests, linting, type checks, and integration tests with caching + parallelization.
+2. Automate Supabase migrations applying via GitHub Actions with safe-guard prompts and automatic backups before applying to production.
+3. Add deployment stages: preview (per PR), staging (merge to main), and production (manual approval) for both Vercel and Cloudflare Worker targets.
+4. Integrate automated smoke tests post-deploy using Playwright against staging, reporting status back to GitHub.
+5. Implement observability hooks (Datadog or Sentry) to capture release metadata, deploy duration, and rollback commands.
+
+**Deliverables**
+- Updated GitHub Actions workflows, environment secrets documentation, and runbook for operations.
+- Scripts or CLI utilities invoked by CI to handle migrations, environment promotion, and rollbacks.
+- Playwright smoke test suite with clear failure diagnostics.
+- Dashboards/alerts that notify the team on failed deployments or slow rollouts.
+
+Ensure the pipeline is idempotent, secure (no plain-text secrets), and supports multi-tenant configuration differences per environment.

--- a/codex-tasks/09-internal-admin-dashboard.md
+++ b/codex-tasks/09-internal-admin-dashboard.md
@@ -1,0 +1,29 @@
+---
+id: "09"
+title: "Internal Admin Dashboard"
+status: "pending"
+priority: "medium"
+category: "polish"
+---
+
+You are building an internal admin dashboard for our support and operations teams to monitor tenant health, track AI assistant performance, and manage escalations. This dashboard will be a restricted Next.js app hosted under `/admin` with Clerk SSO and Supabase row-level permissions.
+
+**Context**
+- Internal tooling is currently a mix of Supabase SQL Editor and manual scripts.
+- We need visibility into message queues, error rates, and tenant billing status.
+- Admins require fine-grained permissions (support, ops, finance).
+
+**Objectives**
+1. Scaffold a protected admin app route at `apps/web/app/admin` with middleware gating by Clerk roles and Supabase policies.
+2. Create dashboards for tenant health (uptime, response latency, queue depth), financial metrics (MRR, churn risk), and AI quality (handoff rate, CSAT). Use our shared charting library.
+3. Build management tools to resend failed webhooks, pause tenants, refund charges, and impersonate support accounts for debugging.
+4. Integrate live logs + alerts from Cloudflare Workers and Supabase using server-sent events or WebSockets.
+5. Document SOPs, permissions matrix, and troubleshooting guides for each admin role.
+
+**Deliverables**
+- Admin app route with modular pages, server actions, and API handlers.
+- Secure backend endpoints enforcing RBAC and logging every action for auditing.
+- Shared components for charts, tables, and activity feeds.
+- Documentation + runbooks for support/ops teams including onboarding checklists.
+
+Ensure the dashboard is performant, secure, and designed for quick iteration as new internal tools are added.

--- a/codex-tasks/10-ai-booking-assistant.md
+++ b/codex-tasks/10-ai-booking-assistant.md
@@ -1,0 +1,29 @@
+---
+id: "10"
+title: "AI Booking Assistant & GPT Auto-Replies"
+status: "pending"
+priority: "high"
+category: "growth"
+---
+
+You are shipping the next iteration of our AI booking assistant that can automatically respond to inquiries, capture structured booking details, and sync confirmed appointments into the salon's calendar. The assistant should operate across SMS, web chat, and email channels.
+
+**Context**
+- The AI pipeline is powered by OpenAI GPT-4o with function calling to our scheduling APIs.
+- Appointments are stored in Supabase and mirrored to Google Calendar via a background worker.
+- Human receptionists can override AI decisions and should remain in control when the AI is uncertain.
+
+**Objectives**
+1. Design conversational flows that collect client intent, preferred stylist, service, and timing. Implement guardrails for PII and compliance.
+2. Build GPT function schemas for booking creation, rescheduling, and cancellation that integrate with Supabase RPCs. Ensure validation + conflict detection.
+3. Implement channel adapters (SMS via Twilio, email via SendGrid, web chat existing widget) that feed into the same AI core and emit standardized events.
+4. Add human-in-the-loop controls in the dashboard Inbox so staff can approve, edit, or reject AI-generated bookings with context.
+5. Measure AI performance with metrics (autonomous booking rate, fallback rate, average handling time) and surface them in analytics dashboards.
+
+**Deliverables**
+- Updated AI orchestration code, function definitions, and worker handlers.
+- Channel adapters with retry/backoff, logging, and observability.
+- Inbox UI enhancements supporting approval workflows and timeline visualization.
+- Documentation covering prompt design, testing scripts, and rollback procedures.
+
+Ensure the assistant maintains high accuracy, gracefully escalates to humans, and complies with salon policy constraints.

--- a/codex-tasks/11-google-zapier-integration.md
+++ b/codex-tasks/11-google-zapier-integration.md
@@ -1,0 +1,29 @@
+---
+id: "11"
+title: "Google Calendar & Zapier Integration"
+status: "pending"
+priority: "medium"
+category: "growth"
+---
+
+You are enabling native integrations with Google Calendar and Zapier so salons can sync bookings to their calendars and automate follow-up workflows. The solution should include OAuth flows, event syncing, and Zapier triggers/actions.
+
+**Context**
+- Appointments are stored in Supabase and currently mirrored to Google Calendar using a service account (single calendar).
+- Tenants want to connect their own Google Workspace calendars and create Zaps for marketing automation.
+- We use Cloudflare Workers for backend APIs and Supabase for storing credentials.
+
+**Objectives**
+1. Implement OAuth 2.0 flows allowing tenants to connect Google Calendar accounts, storing tokens securely with rotation and revocation support.
+2. Build a syncing service that maps Supabase appointments to Google Calendar events per tenant, handling retries, conflict resolution, and webhook push notifications.
+3. Develop Zapier integration with triggers (New Appointment, AI Escalation, Missed Call) and actions (Create Appointment, Send AI Reply). Provide CLI tooling to manage Zapier secrets and schema.
+4. Update dashboard settings UI to manage connected integrations, view sync status, and force resyncs.
+5. Document security considerations, scopes requested, and troubleshooting steps for expired tokens or Zap failures.
+
+**Deliverables**
+- OAuth handlers, Supabase tables, and worker jobs for Google Calendar sync.
+- Zapier app definition, TypeScript code for triggers/actions, and deployment instructions.
+- Dashboard UI components for managing integrations and viewing sync logs.
+- Documentation for onboarding, security review, and support troubleshooting.
+
+Ensure data privacy, tenant isolation, and rate limit compliance for both Google and Zapier APIs.

--- a/codex-tasks/12-white-labeling.md
+++ b/codex-tasks/12-white-labeling.md
@@ -1,0 +1,29 @@
+---
+id: "12"
+title: "White-Labeling Support"
+status: "pending"
+priority: "medium"
+category: "polish"
+---
+
+You are adding comprehensive white-labeling support so enterprise resellers can rebrand the AI receptionist platform for their own salon networks. The goal is to provide configurable themes, domain assets, legal copy, and billing ownership without code changes per reseller.
+
+**Context**
+- Tenant theming currently supports colors and logos but not typography, copy overrides, or email templates.
+- Billing is processed via Stripe with a single account owned by us.
+- Resellers require separate analytics, support contact info, and optional custom AI prompts.
+
+**Objectives**
+1. Extend the theming system to support reseller-level configuration (fonts, icon sets, layout variants) stored in Supabase and consumed by both dashboard and public widgets.
+2. Implement dynamic email + SMS templates that reference reseller branding, legal text, and reply-to addresses. Provide a previewer in the dashboard.
+3. Allow resellers to bring their own Stripe account via Stripe Connect, ensuring invoices and payouts are issued in their name while we retain platform fees.
+4. Introduce a reseller admin portal to manage tenant onboarding, usage analytics, and AI prompt templates. Ensure RBAC prevents cross-reseller data leaks.
+5. Document white-label provisioning steps, including domain setup, asset upload requirements, and billing reconciliation.
+
+**Deliverables**
+- Supabase schema updates, APIs, and caching strategy for reseller configs.
+- Frontend updates for theming, template rendering, and preview flows.
+- Stripe Connect onboarding flows, webhook handlers, and reconciliation jobs.
+- Documentation for internal teams and reseller partners covering setup + ongoing maintenance.
+
+Ensure the solution scales to dozens of resellers, avoids performance regressions, and keeps tenant data segregated.

--- a/codex-tasks/README.md
+++ b/codex-tasks/README.md
@@ -1,0 +1,38 @@
+# Codex Task Automation System
+
+This directory contains the structured prompts and metadata that drive the autonomous Codex task workflow for the AI salon receptionist platform. Each task is expressed as a Markdown file with YAML frontmatter describing its identity, priority, category, and status.
+
+## Directory Layout
+
+- `01-*.md` … `12-*.md` — Individual task briefs written for Codex operators. Frontmatter is always synchronized with the machine index.
+- `index.json` — Machine-readable list of every task with key metadata for pipelines.
+- `README.md` — This guide.
+
+## Usage
+
+1. Install dependencies and ensure TypeScript support is available in the repo (see root `package.json`).
+2. Run the Codex task runner to surface the next pending task:
+   ```bash
+   ts-node scripts/run-codex-task.ts
+   ```
+   or via npm script:
+   ```bash
+   npm run codex
+   ```
+3. Follow the interactive prompts to mark tasks as in progress or done. The CLI updates both `index.json` and the Markdown frontmatter for consistency.
+4. When working in automated environments, pass `--headless` to print the next task without interactive prompts. The output includes metadata and the full prompt body:
+   ```bash
+   ts-node scripts/run-codex-task.ts --headless
+   ```
+
+## Conventions
+
+- Task statuses are `pending`, `in-progress`, or `done`.
+- When updating task files manually, keep the frontmatter keys consistent so the CLI can parse them.
+- Any new tasks must be added to both the Markdown file set and `index.json` to remain discoverable by automation.
+
+## Maintenance
+
+- Review task priorities regularly and reorder files if new initiatives are added.
+- Keep prompts actionable with clear deliverables so Codex can execute autonomously.
+- Update this README if the workflow or CLI behavior changes.

--- a/codex-tasks/index.json
+++ b/codex-tasks/index.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "01",
+    "title": "Responsive UI & UX Polish",
+    "file": "codex-tasks/01-ui-polish.md",
+    "status": "pending",
+    "priority": "high"
+  },
+  {
+    "id": "02",
+    "title": "PWA Support",
+    "file": "codex-tasks/02-pwa-support.md",
+    "status": "pending",
+    "priority": "high"
+  },
+  {
+    "id": "03",
+    "title": "Custom Domains for Tenants",
+    "file": "codex-tasks/03-custom-domains.md",
+    "status": "pending",
+    "priority": "high"
+  },
+  {
+    "id": "04",
+    "title": "GDPR & Legal Compliance Tools",
+    "file": "codex-tasks/04-gdpr-compliance.md",
+    "status": "pending",
+    "priority": "high"
+  },
+  {
+    "id": "05",
+    "title": "Beta Program Workflow",
+    "file": "codex-tasks/05-beta-program.md",
+    "status": "pending",
+    "priority": "medium"
+  },
+  {
+    "id": "06",
+    "title": "In-App Support / Live Chat",
+    "file": "codex-tasks/06-in-app-support.md",
+    "status": "pending",
+    "priority": "medium"
+  },
+  {
+    "id": "07",
+    "title": "Developer CLI & Tenant Tools",
+    "file": "codex-tasks/07-developer-cli.md",
+    "status": "pending",
+    "priority": "medium"
+  },
+  {
+    "id": "08",
+    "title": "CI/CD & Deployment Automation",
+    "file": "codex-tasks/08-cicd-automation.md",
+    "status": "pending",
+    "priority": "medium"
+  },
+  {
+    "id": "09",
+    "title": "Internal Admin Dashboard",
+    "file": "codex-tasks/09-internal-admin-dashboard.md",
+    "status": "pending",
+    "priority": "medium"
+  },
+  {
+    "id": "10",
+    "title": "AI Booking Assistant & GPT Auto-Replies",
+    "file": "codex-tasks/10-ai-booking-assistant.md",
+    "status": "pending",
+    "priority": "high"
+  },
+  {
+    "id": "11",
+    "title": "Google Calendar & Zapier Integration",
+    "file": "codex-tasks/11-google-zapier-integration.md",
+    "status": "pending",
+    "priority": "medium"
+  },
+  {
+    "id": "12",
+    "title": "White-Labeling Support",
+    "file": "codex-tasks/12-white-labeling.md",
+    "status": "pending",
+    "priority": "medium"
+  }
+]

--- a/package.json
+++ b/package.json
@@ -15,16 +15,23 @@
     "dev:worker": "npm run dev --workspace workers/api",
     "deploy:worker": "npm run deploy --workspace workers/api",
     "test": "vitest",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "codex": "ts-node scripts/run-codex-task.ts"
   },
   "devDependencies": {
+    "@types/inquirer": "^8.2.1",
+    "@types/node": "^20.11.19",
     "@playwright/test": "^1.41.2",
     "@testing-library/jest-dom": "^6.1.5",
     "@testing-library/react": "^14.1.2",
     "@testing-library/user-event": "^14.5.2",
     "@vitejs/plugin-react": "^4.2.1",
+    "chalk": "^4.1.2",
+    "gray-matter": "^4.0.3",
+    "inquirer": "^8.2.5",
     "jsdom": "^23.0.0",
     "node-mocks-http": "^1.13.0",
+    "ts-node": "^10.9.2",
     "vitest": "^1.2.2"
   }
 }

--- a/scripts/run-codex-task.ts
+++ b/scripts/run-codex-task.ts
@@ -1,0 +1,170 @@
+import path from 'path';
+import { readFile, writeFile } from 'fs/promises';
+import matter from 'gray-matter';
+import chalk from 'chalk';
+import inquirer from 'inquirer';
+import { spawn } from 'child_process';
+
+interface TaskIndexEntry {
+  id: string;
+  title: string;
+  file: string;
+  status: 'pending' | 'in-progress' | 'done';
+  priority: 'high' | 'medium' | 'low';
+}
+
+interface TaskDetail {
+  entry: TaskIndexEntry;
+  content: string;
+  data: Record<string, unknown>;
+}
+
+const ROOT_DIR = process.cwd();
+const INDEX_PATH = path.join(ROOT_DIR, 'codex-tasks', 'index.json');
+
+async function loadIndex(): Promise<TaskIndexEntry[]> {
+  const raw = await readFile(INDEX_PATH, 'utf8');
+  const parsed = JSON.parse(raw) as TaskIndexEntry[];
+  return parsed;
+}
+
+async function saveIndex(entries: TaskIndexEntry[]): Promise<void> {
+  const serialized = JSON.stringify(entries, null, 2) + '\n';
+  await writeFile(INDEX_PATH, serialized, 'utf8');
+}
+
+async function loadTaskDetail(entry: TaskIndexEntry): Promise<TaskDetail> {
+  const taskPath = path.join(ROOT_DIR, entry.file);
+  const raw = await readFile(taskPath, 'utf8');
+  const parsed = matter(raw);
+  return {
+    entry,
+    content: parsed.content.trimStart() ? parsed.content.replace(/^\n*/, '') : '',
+    data: parsed.data,
+  };
+}
+
+function printTask(detail: TaskDetail): void {
+  const { entry, data, content } = detail;
+  const divider = chalk.gray('────────────────────────────────────────────');
+  console.log(divider);
+  console.log(chalk.bold(`Task ${entry.id}: ${entry.title}`));
+  console.log(chalk.gray(`Priority: ${entry.priority} • Status: ${entry.status}`));
+  console.log(chalk.gray(`File: ${entry.file}`));
+  const meta = { ...data };
+  delete meta.content;
+  console.log(chalk.gray(`Frontmatter: ${JSON.stringify(meta, null, 2)}`));
+  console.log(divider);
+  console.log(content.trim() ? content.trim() : chalk.yellow('No prompt content found.'));
+  console.log(divider);
+}
+
+async function updateTaskStatus(entry: TaskIndexEntry, status: TaskIndexEntry['status']): Promise<void> {
+  const taskPath = path.join(ROOT_DIR, entry.file);
+  const raw = await readFile(taskPath, 'utf8');
+  const parsed = matter(raw);
+  parsed.data.status = status;
+  const nextMarkdown = matter.stringify(parsed.content.replace(/^\n*/, ''), parsed.data).trimEnd() + '\n';
+  await writeFile(taskPath, nextMarkdown, 'utf8');
+}
+
+function withUpdatedStatus(entries: TaskIndexEntry[], entry: TaskIndexEntry, status: TaskIndexEntry['status']): TaskIndexEntry[] {
+  return entries.map((item) => (item.id === entry.id ? { ...item, status } : item));
+}
+
+async function runCommand(command: string, args: string[]): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(command, args, { stdio: 'inherit' });
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`${command} ${args.join(' ')} exited with code ${code}`));
+      }
+    });
+    child.on('error', (err) => reject(err));
+  });
+}
+
+async function runGitCommit(entry: TaskIndexEntry): Promise<void> {
+  const message = `✅ Task ${entry.id} complete: ${entry.title}`;
+  await runCommand('git', ['add', '.']);
+  await runCommand('git', ['commit', '-m', message]);
+  console.log(chalk.green(`Git commit created: ${message}`));
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const headless = args.includes('--headless');
+
+  const index = await loadIndex();
+  const pending = index.find((item) => item.status === 'pending');
+
+  if (!pending) {
+    console.log(chalk.green('No pending Codex tasks found.'));
+    return;
+  }
+
+  const detail = await loadTaskDetail(pending);
+
+  if (headless) {
+    printTask(detail);
+    return;
+  }
+
+  printTask(detail);
+
+  const { markInProgress } = await inquirer.prompt<{ markInProgress: boolean }>([
+    {
+      type: 'confirm',
+      name: 'markInProgress',
+      message: 'Mark this task as in progress?',
+      default: true,
+    },
+  ]);
+
+  if (!markInProgress) {
+    console.log(chalk.yellow('Task left in pending state.'));
+    return;
+  }
+
+  await updateTaskStatus(pending, 'in-progress');
+  await saveIndex(withUpdatedStatus(index, pending, 'in-progress'));
+  console.log(chalk.cyan(`Task ${pending.id} marked as in-progress.`));
+
+  const { markComplete } = await inquirer.prompt<{ markComplete: boolean }>([
+    {
+      type: 'confirm',
+      name: 'markComplete',
+      message: 'Mark as complete and commit?',
+      default: false,
+    },
+  ]);
+
+  if (!markComplete) {
+    return;
+  }
+
+  await updateTaskStatus(pending, 'done');
+  await saveIndex(withUpdatedStatus(await loadIndex(), pending, 'done'));
+  console.log(chalk.green(`Task ${pending.id} marked as done.`));
+
+  try {
+    await runGitCommit(pending);
+  } catch (error) {
+    console.error(chalk.red('Failed to create git commit automatically. Please review manually.'));
+    if (error instanceof Error) {
+      console.error(chalk.red(error.message));
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(chalk.red('run-codex-task failed:'));
+  if (error instanceof Error) {
+    console.error(chalk.red(error.message));
+  } else {
+    console.error(error);
+  }
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a codex-tasks workspace with 12 detailed task briefs and machine-readable index
- document how to use the codex workflow for sequential task execution
- implement an interactive/headless run-codex-task CLI and expose it via npm script

## Testing
- npm run codex -- --headless

------
https://chatgpt.com/codex/tasks/task_e_68e51212ed1883299f0fee4e136fd6c0