### PR TITLE
Harden webhook security and idempotency

### DIFF
--- a/workers/api/src/lib/webhook-security.ts
+++ b/workers/api/src/lib/webhook-security.ts
@@ -1,0 +1,188 @@
+const TWILIO_SIGNATURE_HEADER = 'x-twilio-signature';
+
+export class WebhookVerificationError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status = 400) {
+    super(message);
+    this.name = 'WebhookVerificationError';
+    this.status = status;
+  }
+}
+
+type ParameterMap = Record<string, string[]>;
+
+type TwilioVerificationResult = {
+  payload: Record<string, unknown>;
+};
+
+function parseContentType(raw: string | null): string | null {
+  if (!raw) {
+    return null;
+  }
+  return raw.split(';')[0]?.trim().toLowerCase() ?? null;
+}
+
+function base64ToUint8Array(value: string) {
+  try {
+    const binary = atob(value);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+  } catch (error) {
+    throw new WebhookVerificationError('Invalid signature encoding', 400);
+  }
+}
+
+function timingSafeEqualBase64(a: string, b: string) {
+  const bytesA = base64ToUint8Array(a);
+  const bytesB = base64ToUint8Array(b);
+
+  if (bytesA.length !== bytesB.length) {
+    return false;
+  }
+
+  let result = 0;
+  for (let i = 0; i < bytesA.length; i++) {
+    result |= bytesA[i] ^ bytesB[i];
+  }
+  return result === 0;
+}
+
+function bufferToBase64(buffer: ArrayBuffer) {
+  let binary = '';
+  const bytes = new Uint8Array(buffer);
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+async function computeTwilioSignature(authToken: string, payload: string) {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(authToken),
+    { name: 'HMAC', hash: 'SHA-1' },
+    false,
+    ['sign']
+  );
+  const signature = await crypto.subtle.sign('HMAC', key, encoder.encode(payload));
+  return bufferToBase64(signature);
+}
+
+function parseUrlEncoded(body: string): ParameterMap {
+  const searchParams = new URLSearchParams(body);
+  const map: ParameterMap = {};
+  for (const key of searchParams.keys()) {
+    const values = searchParams.getAll(key);
+    map[key] = values;
+  }
+  return map;
+}
+
+async function parseMultipart(request: Request): Promise<ParameterMap> {
+  const formData = await request.formData();
+  const map: ParameterMap = {};
+  for (const [key, value] of formData.entries()) {
+    if (typeof value === 'string') {
+      if (!map[key]) {
+        map[key] = [];
+      }
+      map[key].push(value);
+    }
+  }
+  return map;
+}
+
+function buildSignaturePayload(url: string, map: ParameterMap, rawBody: string, contentType: string | null) {
+  const hasParams = Object.keys(map).length > 0;
+  if (hasParams && contentType !== 'application/json') {
+    const sortedKeys = Object.keys(map).sort();
+    let buffer = url;
+    for (const key of sortedKeys) {
+      for (const value of map[key]) {
+        buffer += key + value;
+      }
+    }
+    return buffer;
+  }
+  return url + (rawBody ?? '');
+}
+
+function toPayload(map: ParameterMap): Record<string, unknown> {
+  const payload: Record<string, unknown> = {};
+  for (const [key, values] of Object.entries(map)) {
+    if (!values.length) {
+      continue;
+    }
+    payload[key] = values.length === 1 ? values[0] : values;
+  }
+  return payload;
+}
+
+function parseJsonPayload(rawBody: string): Record<string, unknown> {
+  if (!rawBody) {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(rawBody);
+    if (parsed && typeof parsed === 'object') {
+      return parsed as Record<string, unknown>;
+    }
+    return {};
+  } catch (error) {
+    throw new WebhookVerificationError('Invalid JSON payload', 400);
+  }
+}
+
+function inferPayload(map: ParameterMap, rawBody: string, contentType: string | null): Record<string, unknown> {
+  if (Object.keys(map).length > 0) {
+    return toPayload(map);
+  }
+  if (contentType === 'application/json') {
+    return parseJsonPayload(rawBody);
+  }
+  const trimmed = rawBody.trim();
+  if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
+    return parseJsonPayload(rawBody);
+  }
+  return {};
+}
+
+export async function verifyTwilioWebhookRequest(request: Request, authToken: string | undefined): Promise<TwilioVerificationResult> {
+  if (!authToken) {
+    throw new WebhookVerificationError('Twilio auth token not configured', 500);
+  }
+
+  const signature = request.headers.get(TWILIO_SIGNATURE_HEADER);
+  if (!signature) {
+    throw new WebhookVerificationError('Missing Twilio signature header', 403);
+  }
+
+  const contentType = parseContentType(request.headers.get('content-type'));
+  const clone = request.clone();
+  const rawBody = await request.text();
+
+  let parameters: ParameterMap = {};
+  if (contentType === 'application/x-www-form-urlencoded') {
+    parameters = parseUrlEncoded(rawBody);
+  } else if (contentType && contentType.startsWith('multipart/form-data')) {
+    parameters = await parseMultipart(clone);
+  } else if (!contentType && rawBody.includes('=')) {
+    parameters = parseUrlEncoded(rawBody);
+  }
+
+  const payloadToSign = buildSignaturePayload(request.url, parameters, rawBody, contentType);
+  const expectedSignature = await computeTwilioSignature(authToken, payloadToSign);
+
+  if (!timingSafeEqualBase64(signature, expectedSignature)) {
+    throw new WebhookVerificationError('Twilio signature verification failed', 403);
+  }
+
+  const payload = inferPayload(parameters, rawBody, contentType);
+
+  return { payload };
+}

--- a/workers/api/src/routes/messaging.ts
+++ b/workers/api/src/routes/messaging.ts
@@ -1,7 +1,7 @@
 import { normalizeError } from '@ai-hairdresser/shared';
 import { Router } from 'itty-router';
 import { JsonResponse } from '../lib/response';
-import { sendOutboundMessage, handleInboundMessage } from '../services/messaging-service';
+import { sendOutboundMessage, handleInboundMessage, normalizeInboundMessagePayload } from '../services/messaging-service';
 
 const router = Router({ base: '/messaging' });
 
@@ -22,8 +22,12 @@ router.post('/outbound', async (request: TenantScopedRequest, env: Env) => {
 });
 
 router.post('/inbound', async (request: Request, env: Env) => {
-  const payload = await request.json();
-  const result = await handleInboundMessage(env, payload);
+  const payload = await request.json().catch(() => null);
+  if (!payload || typeof payload !== 'object') {
+    return JsonResponse.error('Invalid JSON body', 400);
+  }
+  const normalized = normalizeInboundMessagePayload(payload);
+  const result = await handleInboundMessage(env, normalized);
   return JsonResponse.ok(result);
 });
 

--- a/workers/api/src/routes/webhooks.ts
+++ b/workers/api/src/routes/webhooks.ts
@@ -2,9 +2,12 @@ import { Router } from 'itty-router';
 import { JsonResponse } from '../lib/response';
 import { createStripeClient } from '../integrations/stripe';
 import { handleStripeEvent } from '../services/payment-service';
-import { handleInboundMessage } from '../services/messaging-service';
+import { handleInboundMessage, normalizeInboundMessagePayload } from '../services/messaging-service';
+import { verifyTwilioWebhookRequest, WebhookVerificationError } from '../lib/webhook-security';
 
 const router = Router({ base: '/webhooks' });
+
+const IDEMP_TTL_SECONDS = 60 * 60 * 24;
 
 router.post('/stripe', async (request: Request, env: Env) => {
   const signature = request.headers.get('stripe-signature');
@@ -13,7 +16,19 @@ router.post('/stripe', async (request: Request, env: Env) => {
 
   try {
     const event = await stripe.retrieveEvent(signature, payload);
+    const eventId = (event as { id?: string } | null)?.id;
+    if (!eventId) {
+      throw new Error('Stripe event missing id');
+    }
+
+    const cacheKey = `stripe:${eventId}`;
+    if (await env.IDEMP_KV.get(cacheKey)) {
+      return JsonResponse.ok({ received: true, duplicate: true });
+    }
+
     await handleStripeEvent(env, event as Record<string, unknown>);
+    await env.IDEMP_KV.put(cacheKey, '1', { expirationTtl: IDEMP_TTL_SECONDS });
+
     return JsonResponse.ok({ received: true });
   } catch (error) {
     console.error('Stripe webhook error', error);
@@ -22,9 +37,30 @@ router.post('/stripe', async (request: Request, env: Env) => {
 });
 
 router.post('/twilio', async (request: Request, env: Env) => {
-  const payload = await request.json();
-  const result = await handleInboundMessage(env, payload);
-  return JsonResponse.ok(result);
+  try {
+    const { payload } = await verifyTwilioWebhookRequest(request, env.TWILIO_AUTH_TOKEN);
+    const message = normalizeInboundMessagePayload(payload);
+
+    if (message.messageSid) {
+      const cacheKey = `twilio:${message.messageSid}`;
+      if (await env.IDEMP_KV.get(cacheKey)) {
+        return JsonResponse.ok({ received: true, duplicate: true });
+      }
+      const result = await handleInboundMessage(env, message);
+      await env.IDEMP_KV.put(cacheKey, '1', { expirationTtl: IDEMP_TTL_SECONDS });
+      return JsonResponse.ok(result);
+    }
+
+    const result = await handleInboundMessage(env, message);
+    return JsonResponse.ok(result);
+  } catch (error) {
+    if (error instanceof WebhookVerificationError) {
+      console.warn('Twilio webhook rejected', { reason: error.message });
+      return JsonResponse.error('Forbidden', error.status);
+    }
+    console.error('Twilio webhook error', error);
+    return JsonResponse.error('Unable to process Twilio webhook', 400);
+  }
 });
 
 export const webhooksRouter = router;

--- a/workers/api/src/services/messaging-service.ts
+++ b/workers/api/src/services/messaging-service.ts
@@ -1,17 +1,85 @@
+import { RequestLogger, normalizeError } from '@ai-hairdresser/shared';
+
 import { createTwilioClient } from '../integrations/twilio';
 import { callOpenAI } from '../integrations/openai';
-
-import { RequestLogger, normalizeError } from '@ai-hairdresser/shared';
 import { createSystemLogger } from '../lib/observability';
-
 import { checkUsageQuota, recordUsageEvent } from './usage-service';
-
 
 type OutboundPayload = {
   to: string;
   body: string;
   channel?: 'sms' | 'whatsapp';
 };
+
+export type NormalizedInboundMessage = {
+  raw: Record<string, unknown>;
+  body?: string;
+  from?: string;
+  to?: string;
+  channel?: 'sms' | 'whatsapp' | 'voice';
+  messageSid?: string;
+  tenantId?: string | null;
+};
+
+function maskRecipient(recipient?: string) {
+  if (!recipient) {
+    return 'unknown';
+  }
+  const stripped = recipient.replace(/[^\d]+/g, '');
+  if (stripped.length <= 4) {
+    return `***${stripped}`;
+  }
+  return `***${stripped.slice(-4)}`;
+}
+
+function detectChannel(raw: Record<string, unknown>, from?: string, to?: string): NormalizedInboundMessage['channel'] {
+  if (raw.CallSid || raw.CallStatus || raw.CallDuration) {
+    return 'voice';
+  }
+  const channelHint = typeof raw.Channel === 'string' ? raw.Channel : typeof raw.channel === 'string' ? raw.channel : undefined;
+  if (channelHint && channelHint.toLowerCase().includes('whatsapp')) {
+    return 'whatsapp';
+  }
+  if (from?.toLowerCase().startsWith('whatsapp:') || to?.toLowerCase().startsWith('whatsapp:')) {
+    return 'whatsapp';
+  }
+  return from || to ? 'sms' : undefined;
+}
+
+function coerceString(value: unknown): string | undefined {
+  if (typeof value === 'string' && value.length > 0) {
+    return value;
+  }
+  return undefined;
+}
+
+export function normalizeInboundMessagePayload(payload: unknown): NormalizedInboundMessage {
+  if (payload && typeof payload === 'object' && 'raw' in (payload as Record<string, unknown>)) {
+    return payload as NormalizedInboundMessage;
+  }
+
+  const raw = payload && typeof payload === 'object' && payload !== null ? (payload as Record<string, unknown>) : {};
+  const body = coerceString(raw.Body ?? raw.body ?? raw.Message ?? raw.message);
+  const from = coerceString(raw.From ?? raw.from ?? raw.Caller ?? raw.caller);
+  const to = coerceString(raw.To ?? raw.to ?? raw.Recipient ?? raw.recipient);
+  const messageSid = coerceString(
+    raw.MessageSid ?? raw.SmsMessageSid ?? raw.SmsSid ?? raw.CallSid ?? raw.CallSid ?? raw.EventSid ?? raw.sid ?? raw.SID
+  );
+  const tenantCandidate = raw.tenantId ?? raw.TenantId ?? raw.tenant_id;
+  const tenantId = typeof tenantCandidate === 'string' && tenantCandidate.length > 0 ? tenantCandidate : null;
+
+  const channel = detectChannel(raw, from, to);
+
+  return {
+    raw,
+    body,
+    from,
+    to,
+    channel,
+    messageSid,
+    tenantId
+  };
+}
 
 export async function sendOutboundMessage(
   env: Env,
@@ -23,48 +91,70 @@ export async function sendOutboundMessage(
     throw new Error('Missing recipient or message body');
   }
 
-
-  const logger = parentLogger?.child({ component: 'messaging.outbound', tenantId }) ??
+  const logger =
+    parentLogger?.child({ component: 'messaging.outbound', tenantId }) ??
     createSystemLogger({ component: 'messaging.outbound', tenantId });
-  const client = createTwilioClient(env, logger);
-  logger.info('Queue outbound message', { tenantId, to: payload.to ? `***${String(payload.to).slice(-4)}` : 'unknown' });
+
+  logger.info('Queue outbound message', { tenantId, to: maskRecipient(payload.to), channel: payload.channel ?? 'sms' });
 
   await checkUsageQuota(env, tenantId, 'message.sent', 1);
-  const client = createTwilioClient(env);
-  console.log('Queue outbound message', { tenantId, to: payload.to, channel: payload.channel ?? 'sms' })
 
+  const client = createTwilioClient(env, logger);
   const channel = payload.channel ?? 'sms';
-  const result =
-    channel === 'whatsapp'
-      ? await client.sendWhatsapp(payload.to, payload.body)
-      : await client.sendSms(payload.to, payload.body);
+  try {
+    const result =
+      channel === 'whatsapp'
+        ? await client.sendWhatsapp(payload.to, payload.body)
+        : await client.sendSms(payload.to, payload.body);
 
-  await recordUsageEvent(env, tenantId, 'message.sent', {
-    metadata: {
-      channel,
-      hasRecipient: Boolean(payload.to)
-    }
-  });
+    await recordUsageEvent(env, tenantId, 'message.sent', {
+      metadata: {
+        channel,
+        hasRecipient: Boolean(payload.to)
+      }
+    });
 
-  return { status: 'queued', sid: result.sid, channel };
+    return { status: 'queued', sid: result.sid, channel };
+  } catch (error) {
+    logger.error('Failed to send outbound message', { error: normalizeError(error) });
+    throw error;
+  }
 }
 
-export async function handleInboundMessage(env: Env, payload: any, parentLogger?: RequestLogger) {
-  const logger = parentLogger?.child({ component: 'messaging.inbound' }) ??
-    createSystemLogger({ component: 'messaging.inbound' });
-  logger.info('Inbound message payload received', {
-    to: payload?.to ? `***${String(payload.to).slice(-4)}` : 'unknown'
+function isNormalizedInboundMessage(value: unknown): value is NormalizedInboundMessage {
+  return Boolean(value && typeof value === 'object' && 'raw' in (value as Record<string, unknown>));
+}
+
+export async function handleInboundMessage(env: Env, payload: unknown, parentLogger?: RequestLogger) {
+  const message = isNormalizedInboundMessage(payload) ? (payload as NormalizedInboundMessage) : normalizeInboundMessagePayload(payload);
+
+  const logger =
+    parentLogger?.child({ component: 'messaging.inbound', channel: message.channel ?? 'unknown' }) ??
+    createSystemLogger({ component: 'messaging.inbound', channel: message.channel ?? 'unknown' });
+
+  logger.info('Inbound message received', {
+    from: maskRecipient(message.from),
+    to: maskRecipient(message.to),
+    channel: message.channel ?? 'unknown',
+    messageSid: message.messageSid ? `***${message.messageSid.slice(-6)}` : undefined
   });
-  const aiResponse = await callOpenAI(env, {
-export async function handleInboundMessage(env: Env, payload: any) {
-  console.log('Inbound message payload', payload);
-  const aiResponse = await callOpenAI(env, payload?.tenantId ?? null, {
-    prompt: `Client message: ${payload.body}. Respond as a helpful salon receptionist.`
+
+  const trimmedBody = message.body?.trim() ?? '';
+  const prompt =
+    trimmedBody.length > 0
+      ? `Client message: ${trimmedBody}. Respond as a helpful salon receptionist.`
+      : 'Respond as a helpful salon receptionist acknowledging the incoming message.';
+
+  const aiResponse = await callOpenAI(env, message.tenantId ?? null, { prompt });
+
+  logger.debug('Generated AI response for inbound message', {
+    messageSid: message.messageSid ? `***${message.messageSid.slice(-6)}` : undefined
   });
-  logger.debug('Generated AI response for inbound message');
+
   return {
     action: 'respond',
     aiResponse,
-    fallback: payload.body?.includes('agent')
+    fallback: trimmedBody.toLowerCase().includes('agent'),
+    messageSid: message.messageSid
   };
 }

--- a/workers/api/src/types/env.d.ts
+++ b/workers/api/src/types/env.d.ts
@@ -1,5 +1,6 @@
 
 import type { RequestLogger } from '@ai-hairdresser/shared';
+import type { KVNamespace } from '@cloudflare/workers-types';
 
 
 type Role = import('@ai-hairdresser/shared').Role;
@@ -12,6 +13,7 @@ interface Env {
   SUPABASE_SERVICE_ROLE_KEY: string;
   JWT_SECRET: string;
   MULTITENANT_SIGNING_KEY: string;
+  IDEMP_KV: KVNamespace;
   STRIPE_SECRET_KEY: string;
   STRIPE_WEBHOOK_SECRET: string;
   STRIPE_DEFAULT_PRICE_ID: string;

--- a/workers/api/wrangler.toml
+++ b/workers/api/wrangler.toml
@@ -14,6 +14,11 @@ TWILIO_ACCOUNT_SID = "${TWILIO_ACCOUNT_SID}"
 TWILIO_AUTH_TOKEN = "${TWILIO_AUTH_TOKEN}"
 OPENAI_API_KEY = "${OPENAI_API_KEY}"
 
+[[kv_namespaces]]
+binding = "IDEMP_KV"
+id = "${IDEMP_KV_ID}"
+preview_id = "${IDEMP_KV_PREVIEW_ID}"
+
 [env.production]
 route = "api.yourdomain.com/*"
 account_id = "${CLOUDFLARE_ACCOUNT_ID}"


### PR DESCRIPTION
## Summary
- add a shared webhook security helper to verify Twilio signatures and surface structured errors
- enforce Stripe and Twilio webhook idempotency using a KV namespace and normalize inbound messaging payloads
- wire the new KV binding into the worker environment typings and Wrangler configuration

## Testing
- `npm test` *(fails: existing esbuild parsing errors in appointment-service.ts, notification-service.ts, and shared constants)*

------
https://chatgpt.com/codex/tasks/task_e_68e826ab29348329ad40ae718ee3dc8d